### PR TITLE
Improve XieDelhommeau implementation and documentation

### DIFF
--- a/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
+++ b/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
@@ -73,9 +73,10 @@ CONTAINS
       !================================================
 
 #ifdef XIE_CORRECTION
-      VS(3) = CMPLX(integrals(1, 2)/PI - ONE/r1, integrals(2, 2), KIND=PRE)
+      VS(3) = CMPLX(integrals(1, 2)/PI + ONE/r1, integrals(2, 2), KIND=PRE)
 #else
       VS(3) = CMPLX(integrals(1, 2)/PI, integrals(2, 2), KIND=PRE)
+      FS    = CMPLX(integrals(1, 2)/PI, integrals(2, 2), KIND=PRE)
 #endif
       FS    = CMPLX(integrals(1, 2)/PI, integrals(2, 2), KIND=PRE)
 
@@ -124,11 +125,13 @@ CONTAINS
     SP  = 2*wavenumber*SP
     VSP = 2*wavenumber**2*VSP
 
-#ifdef XIE_CORRECTION
-#else
-    ! Only one singularity is missing in the derivative
     XJ_REFLECTION(1:2) = X0J(1:2)
     XJ_REFLECTION(3) = - X0J(3)
+#ifdef XIE_CORRECTION
+    ! SP = SP + 2/NORM2(X0I-XJ_REFLECTION)
+    ! VSP = VSP - 2*(X0I - XJ_REFLECTION)/(NORM2(X0I-XJ_REFLECTION)**3)
+#else
+    ! Only one singularity is missing in the derivative
     VSP = VSP - 2*(X0I - XJ_REFLECTION)/(NORM2(X0I-XJ_REFLECTION)**3)
 #endif
 

--- a/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
+++ b/capytaine/green_functions/Delhommeau_f90/Green_wave.f90
@@ -72,16 +72,14 @@ CONTAINS
       ! Add the elementary integrals to build FS and VS
       !================================================
 
+      FS    = CMPLX(integrals(1, 2)/PI, integrals(2, 2), KIND=PRE)
+      VS(1) = -CMPLX(integrals(1, 1)/PI, integrals(2, 1), KIND=PRE) * wavenumber * (X0I(1) - X0J(1))/r
+      VS(2) = -CMPLX(integrals(1, 1)/PI, integrals(2, 1), KIND=PRE) * wavenumber * (X0I(2) - X0J(2))/r
 #ifdef XIE_CORRECTION
       VS(3) = CMPLX(integrals(1, 2)/PI + ONE/r1, integrals(2, 2), KIND=PRE)
 #else
       VS(3) = CMPLX(integrals(1, 2)/PI, integrals(2, 2), KIND=PRE)
-      FS    = CMPLX(integrals(1, 2)/PI, integrals(2, 2), KIND=PRE)
 #endif
-      FS    = CMPLX(integrals(1, 2)/PI, integrals(2, 2), KIND=PRE)
-
-      VS(1) = -CMPLX(integrals(1, 1)/PI, integrals(2, 1), KIND=PRE) * wavenumber * (X0I(1) - X0J(1))/r
-      VS(2) = -CMPLX(integrals(1, 1)/PI, integrals(2, 1), KIND=PRE) * wavenumber * (X0I(2) - X0J(2))/r
 
       IF (r < REAL(1e-5, KIND=PRE)) THEN
         ! Limit case r ~ 0 ?
@@ -125,12 +123,10 @@ CONTAINS
     SP  = 2*wavenumber*SP
     VSP = 2*wavenumber**2*VSP
 
+#ifndef XIE_CORRECTION
+    ! In the original Delhommeau method
     XJ_REFLECTION(1:2) = X0J(1:2)
     XJ_REFLECTION(3) = - X0J(3)
-#ifdef XIE_CORRECTION
-    ! SP = SP + 2/NORM2(X0I-XJ_REFLECTION)
-    ! VSP = VSP - 2*(X0I - XJ_REFLECTION)/(NORM2(X0I-XJ_REFLECTION)**3)
-#else
     ! Only one singularity is missing in the derivative
     VSP = VSP - 2*(X0I - XJ_REFLECTION)/(NORM2(X0I-XJ_REFLECTION)**3)
 #endif
@@ -191,14 +187,13 @@ CONTAINS
       tabulated_r_range, tabulated_z_range, tabulated_integrals, &
       FS(1), VS(:, 1))
 
-    ! The Delhommeau integrals are actually Re[ ∫(J(ζ) - 1/ζ)dθ ]/π + i Re[ ∫(e^ζ)dθ ]
+#ifndef XIE_CORRECTION
+    ! In the original Delhommeau method, the integrals are Re[ ∫(J(ζ) - 1/ζ)dθ ]/π + i Re[ ∫(e^ζ)dθ ]
     ! whereas we need Re[ ∫(J(ζ))dθ ]/π + i Re[ ∫(e^ζ)dθ ]
     ! So the term PSR is the difference because  Re[ ∫ 1/ζ dθ ] = - π/sqrt(r² + z²)
     !
     ! Note however, that the derivative part of Delhommeau integrals is the derivative of
     ! Re[ ∫(J(ζ))dθ ]/π + i Re[ ∫(e^ζ)dθ ] so no fix is needed for the derivative.
-
-#ifndef XIE_CORRECTION
     PSR(1) = ONE/(wavenumber*SQRT(R**2+(XI(3)+XJ(3))**2))
 #endif
 

--- a/capytaine/green_functions/Delhommeau_f90/matrices.f90
+++ b/capytaine/green_functions/Delhommeau_f90/matrices.f90
@@ -277,6 +277,13 @@ CONTAINS
     !  Reflected Rankine part  !
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+#ifdef XIE_CORRECTION
+    IF (is_infinity(depth)) THEN
+!     ! A term 1/r1 is missing in the Green part. We add it here.
+      coeffs(2) = coeffs(2) + 2*coeffs(3)
+    ENDIF
+#endif
+
     IF (coeffs(2) .NE. ZERO) THEN
 
       IF (is_infinity(depth)) THEN

--- a/capytaine/green_functions/Delhommeau_f90/matrices.f90
+++ b/capytaine/green_functions/Delhommeau_f90/matrices.f90
@@ -246,10 +246,8 @@ CONTAINS
     COMPLEX(KIND=PRE), DIMENSION(nb_faces_1, nb_faces_2), INTENT(OUT) :: K
 
     ! Local variables
-    INTEGER :: I, J
+    INTEGER :: I
     REAL(KIND=PRE), DIMENSION(nb_faces_1, 3) :: reflected_centers_1, reflected_normals_1
-    REAL(KIND=PRE)               :: SP1, SP1b
-    REAL(KIND=PRE), DIMENSION(3) :: VSP1, VSP1b
 
 
     !!!!!!!!!!!!!!!!!!!!

--- a/capytaine/green_functions/Delhommeau_f90/matrices.f90
+++ b/capytaine/green_functions/Delhommeau_f90/matrices.f90
@@ -246,8 +246,10 @@ CONTAINS
     COMPLEX(KIND=PRE), DIMENSION(nb_faces_1, nb_faces_2), INTENT(OUT) :: K
 
     ! Local variables
-    INTEGER :: I
+    INTEGER :: I, J
     REAL(KIND=PRE), DIMENSION(nb_faces_1, 3) :: reflected_centers_1, reflected_normals_1
+    REAL(KIND=PRE)               :: SP1
+    REAL(KIND=PRE), DIMENSION(3) :: VSP1
 
 
     !!!!!!!!!!!!!!!!!!!!
@@ -277,37 +279,48 @@ CONTAINS
     !  Reflected Rankine part  !
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-#ifdef XIE_CORRECTION
     IF (is_infinity(depth)) THEN
-!     ! A term 1/r1 is missing in the Green part. We add it here.
-      coeffs(2) = coeffs(2) + 2*coeffs(3)
-    ENDIF
-#endif
-
-    IF (coeffs(2) .NE. ZERO) THEN
-
-      IF (is_infinity(depth)) THEN
-        ! Reflection through free surface
-        reflected_centers_1(:, 1:2) = centers_1(:, 1:2)
-        reflected_centers_1(:, 3)   = -centers_1(:, 3)
-      ELSE
-        ! Reflection through sea bottom
-        reflected_centers_1(:, 1:2) = centers_1(:, 1:2)
-        reflected_centers_1(:, 3)   = -centers_1(:, 3) - 2*depth
-      END IF
-
-      reflected_normals_1(:, 1:2) = normals_1(:, 1:2)
-      reflected_normals_1(:, 3)   = -normals_1(:, 3)
-
-      CALL ADD_RANKINE_PART_TO_THE_MATRICES(                            &
-        nb_faces_1,                                                     &
-        reflected_centers_1, reflected_normals_1,                       &
-        nb_vertices_2, nb_faces_2,                                      &
-        vertices_2, faces_2, centers_2, normals_2, areas_2, radiuses_2, &
-        coeffs(2),                                                      &
-        S, K)
-
+      ! Reflection through free surface
+      reflected_centers_1(:, 1:2) = centers_1(:, 1:2)
+      reflected_centers_1(:, 3)   = -centers_1(:, 3)
+    ELSE
+      ! Reflection through sea bottom
+      reflected_centers_1(:, 1:2) = centers_1(:, 1:2)
+      reflected_centers_1(:, 3)   = -centers_1(:, 3) - 2*depth
     END IF
+
+    reflected_normals_1(:, 1:2) = normals_1(:, 1:2)
+    reflected_normals_1(:, 3)   = -normals_1(:, 3)
+
+    DO I = 1, nb_faces_1
+      DO J = 1, nb_faces_2
+
+        CALL COMPUTE_INTEGRAL_OF_RANKINE_SOURCE( &
+          reflected_centers_1(I, :),             &
+          vertices_2(faces_2(J, :), :),          &
+          centers_2(J, :),                       &
+          normals_2(J, :),                       &
+          areas_2(J),                            &
+          radiuses_2(J),                         &
+          SP1, VSP1                              &
+          )
+
+        ! Store into influence matrix
+        S(I, J) = S(I, J) - coeffs(2) * SP1/(4*PI)                                ! Green function
+        K(I, J) = K(I, J) - coeffs(2) * DOT_PRODUCT(reflected_normals_1(I, :), VSP1)/(4*PI) ! Gradient of the Green function
+
+#ifdef XIE_CORRECTION
+        CALL COMPUTE_ASYMPTOTIC_RANKINE_SOURCE( &
+          reflected_centers_1(I, :),            &
+          centers_2(J, :),                      &
+          areas_2(J),                           &
+          SP1, VSP1                             &
+          )
+        S(I, J) = S(I, J) - 2 * SP1/(4*PI)                                ! Green function
+        K(I, J) = K(I, J) - 2 * DOT_PRODUCT(reflected_normals_1(I, :), VSP1)/(4*PI) ! Gradient of the Green function
+#endif
+      END DO
+    END DO
 
     !!!!!!!!!!!!!!!
     !  Wave part  !

--- a/capytaine/green_functions/delhommeau.py
+++ b/capytaine/green_functions/delhommeau.py
@@ -182,7 +182,7 @@ class Delhommeau(AbstractGreenFunction):
             elif wavenumber == np.infty:
                 coeffs = np.array((1.0, -1.0, 0.0))
             else:
-                coeffs = np.array((1.0, -1.0, 1.0))
+                coeffs = np.array((1.0, 1.0, 1.0))
 
         else:  # Finite depth
             a_exp, lamda_exp = self.find_best_exponential_decomposition(

--- a/docs/theory_manual/bibliography.rst
+++ b/docs/theory_manual/bibliography.rst
@@ -16,3 +16,5 @@ Bibliography
 .. [X18] Xie et al, **Comparison of existing methods for the calculation of the infinite water depth free-surface Green function for the wave-structure interaction problem**, Applied Ocean Research 81 (2018) 150--163
 
 .. [FK20] Falnes and Kurniawan, **Ocean waves and oscillating systems linear interactions including wave energy extraction**, Cambridge University Press, 2020.
+
+.. [N20] Newman, **A simplified derivation of the ordinary differential equations for the free-surface Green functions**, Applied Ocean Research, 2020

--- a/docs/theory_manual/bibliography.rst
+++ b/docs/theory_manual/bibliography.rst
@@ -1,6 +1,8 @@
 Bibliography
 ============
 
+.. [N82] Noblesse, **The Green function in the theory of radiation and diffraction of regular water waves by a body**, J. Engg. Math., 1982
+
 .. [Del87] Delhommeau, **Problèmes de diffraction-radiation et de résistance des vagues : étude théorique et résolution numérique par la méthode des singularités**, PhD Thesis, École Nationale Supérieure de Mécanique de Nantes, 1987
 
 .. [Del89] Delhommeau, **Amélioration des codes de calcul de diffraction-raditation au premier ordre**, 2émes Journées de l'Hydrodynamique, 1989
@@ -15,6 +17,6 @@ Bibliography
 
 .. [X18] Xie et al, **Comparison of existing methods for the calculation of the infinite water depth free-surface Green function for the wave-structure interaction problem**, Applied Ocean Research 81 (2018) 150--163
 
-.. [FK20] Falnes and Kurniawan, **Ocean waves and oscillating systems linear interactions including wave energy extraction**, Cambridge University Press, 2020.
+.. .. [FK20] Falnes and Kurniawan, **Ocean waves and oscillating systems linear interactions including wave energy extraction**, Cambridge University Press, 2020.
 
 .. [N20] Newman, **A simplified derivation of the ordinary differential equations for the free-surface Green functions**, Applied Ocean Research, 2020

--- a/docs/theory_manual/theory.rst
+++ b/docs/theory_manual/theory.rst
@@ -192,6 +192,7 @@ The first term of :eq:`green_function_inf_depth_xie` is actually a Rankine-type 
 Variants of the formulation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+
 .. _integrate_one_over_zeta:
 
 .. proof:lemma::
@@ -211,12 +212,33 @@ The above lemma allows to retrieve the expression of the Green function found e.
 
 .. proof:lemma::
 
-    The following identity holds [X18]_:
+    The `zeroth order Bessel function of the first kind <https://personal.math.ubc.ca/~cbm/aands/page_360.htm>`_ :math:`J_0` and `the Struve function <https://personal.math.ubc.ca/~cbm/aands/page_496.htm>`_ :math:`H_0` are such that
 
     .. math::
-        \Re \left( \int^{\pi/2}_{-\pi/2} e^{\zeta} \, \mathrm{d} \theta \right) = \pi e^z J_0(r)
+        J_0(r) & = \frac{1}{\pi} \int_{-\pi/2}^{\pi/2} \cos(r\cos(\theta)) \, \mathrm{d} \theta \\
+        H_0(r) & = \frac{1}{\pi} \int_{-\pi/2}^{\pi/2} \sin(r\cos(\theta)) \, \mathrm{d} \theta \\
 
-    where :math:`J_0` is the zeroth order Bessel function of the first kind.
+    hence
+
+    .. math::
+        \int_{-\pi/2}^{\pi/2} i e^{\zeta} \, \mathrm{d} \theta = \pi e^z \left(- H_0(r) + i J_0(r) \right)
+
+
+The function :math:`\mathcal{G}` can also be rewritten as
+
+.. math::
+    \mathcal{G}(r, z) & = \frac{1}{\sqrt{r^2 + z^2}} + \frac{2}{\pi} \int^{\pi/2}_{-\pi/2} \Re \left( e^\zeta E_1(\zeta) \right) \, \mathrm{d} \theta + 2 \int^{\pi/2}_{-\pi/2} i e^{\zeta (r, z, \theta)} \, \mathrm{d} \theta \\
+    & = \frac{1}{\sqrt{r^2 + z^2}} + \frac{2}{\pi} \int^{\pi/2}_{-\pi/2} \Re \left( e^\zeta E_1(\zeta) \right) \, \mathrm{d} \theta + 2 \pi e^z \left( - H_0(r) + i J_0(r) \right)
+
+Noblesse [N82]_ splits the function :math:`\mathcal{G}` into a near field term :math:`N` and a wave field :math:`W` such that
+
+.. math::
+   N(r, z) & = \frac{1}{\sqrt{r^2 + z^2}} + \frac{2}{\pi} \int^{\pi/2}_{-\pi/2} \Re \left( e^\zeta E_1(\zeta)  \right) \, \mathrm{d} \theta  \\
+   W(r, z) & = 2 \pi e^z \left( - H_0(r) + i J_0(r) \right)
+
+
+Note that :math:`E_1`, :math:`J_0` and :math:`H_0` are available for instance in the `Scipy library <https://docs.scipy.org/doc/scipy/reference/special.html>`_.
+
 
 .. proof:lemma::
 

--- a/docs/theory_manual/theory.rst
+++ b/docs/theory_manual/theory.rst
@@ -146,63 +146,11 @@ See also [X18]_.
 Green function
 ~~~~~~~~~~~~~~
 
-The Green function can be written as the sum of three terms:
+The infinite depth Green function takes the following form
 
 .. math::
-   G(\xi, x) = - \frac{1}{4 \pi} \left( G_0(\xi, x) + G_1(\xi, x) + G_2(\xi, x) \right)
-   :label: green_function
-
-The first term
-
-.. math::
-    G_0(\xi, x) = \frac{1}{\|x - \xi\|}
-    :label: green_function_inf_depth_0
-
-is the usual Green function for the 3D Laplace equation without our specific boundary conditions.
-
-The second part reads
-
-.. math::
-    G_1(\xi, x) = - \frac{1}{\|x - s(\xi)\|}
-    :label: green_function_inf_depth_1
-
-where :math:`s(\xi_1, \xi_2, \xi_3) = (\xi_1, \xi_2, -\xi_3)` is the reflection of :math:`\xi` across the free surface.
-
-Finally, this last part is complex-valued and it is introduced to satisfy the boundary conditions :eq:`bc_fs`.
-It depends on the water depth :math:`h` and the wave frequency :math:`\omega` (through the wave number :math:`k`).
-
-.. math::
-    G_2(\xi, x) & =
-    \frac{2 k}{\pi} \Re \left( \int^{\pi/2}_{-\pi/2} \left( J(\zeta(x, \xi, \theta)) - \frac{1}{\zeta(x, \xi, \theta)} \right) \, \mathrm{d} \theta \right) \\
-    & \qquad \qquad \qquad \qquad + 2 i k \Re \left( \int^{\pi/2}_{-\pi/2} e^{\zeta (x, \xi, \theta)} \, \mathrm{d} \theta \right)
-    :label: green_function_inf_depth_2
-
-where
-
-.. math::
-    J(z) =
-    \begin{cases}
-    e^z \left[ E_1(z) + i\pi \right] \quad \text{if} ~ \Im(z) \ge 0 \\
-    e^z \left[ E_1(z) - i\pi \right] \quad \text{if} ~ \Im(z) < 0
-    \end{cases}
-
-where :math:`E_1` is the first exponential integral, defined as
-
-.. math::
-    E_1(z) = \int_z^\infty \frac{e^{-t}}{t} dt,
-
-and
-
-.. math::
-    \zeta (x, \xi, \theta) = k \left( x_3 + \xi_3 + i r \cos \theta \right)
-    :label: def_zeta
-
-where
-
-.. math::
-    r = \sqrt{(\xi_1 - x_1)^2 + (\xi_2 - x_2)^2}.
-    :label: def_r
-
+   G(\xi, x) = - \frac{1}{4 \pi} \left( \frac{1}{\|x - \xi\|} + k \mathcal{G}\left(k \sqrt{(x_1 - \xi_1)^2 + (x_2 - \xi_2)^2}, k (x_3 + \xi_3) \right) \right)
+   :label: green_function_inf_depth
 
 .. proof:property::
 
@@ -211,6 +159,35 @@ where
    .. math::
 
         \forall x, \xi, \quad G(x, \xi) = G(\xi, x).
+
+
+The first term of :math:`G` is the usual Green function for the 3D Laplace equation without our specific boundary conditions.
+The :math:`\mathcal{G}` term is complex-valued and it is introduced to satisfy the boundary conditions :eq:`bc_fs`.
+
+Intoducting the dimensionless variables :math:`r = k \sqrt{(\xi_1 - x_1)^2 + (\xi_2 - x_2)^2}` and :math:`z = k (x_3 + \xi_3)`, this term reads
+
+.. math::
+    \mathcal{G}(r, z) & = \frac{1}{\sqrt{r^2 + z^2}} + \frac{2}{\pi} \Re \left( \int^{\pi/2}_{-\pi/2}  J(\zeta(r, z, \theta)) \, \mathrm{d} \theta \right) \\
+    & \qquad \qquad \qquad \qquad + 2 i \Re \left( \int^{\pi/2}_{-\pi/2} e^{\zeta (r, z, \theta)} \, \mathrm{d} \theta \right)
+    :label: green_function_inf_depth_xie
+
+where
+
+.. math::
+    J(\zeta) = e^\zeta \left[ E_1(\zeta) + i \pi \right]
+
+where :math:`E_1` is the first exponential integral, defined as
+
+.. math::
+    E_1(\zeta) = \int_\zeta^\infty \frac{e^{-t}}{t} dt,
+
+and
+
+.. math::
+    \zeta (r, z, \theta) = z + i r \cos \theta.
+    :label: def_zeta
+
+The first term of :eq:`green_function_inf_depth_xie` is actually a Rankine-type singularity similar to the first term of :eq:`green_function_inf_depth`, except that one of the point has been reflected through the free surface.
 
 Variants of the formulation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -222,23 +199,28 @@ Variants of the formulation
     The following identity holds [Del89]_:
 
     .. math::
-       \Re \int^{\pi/2}_{-\pi/2} \frac{1}{\zeta(\theta)} \, \mathrm{d} \theta = - \frac{\pi}{k \|x - s(\xi)\|}.
+       \Re \int^{\pi/2}_{-\pi/2} \frac{1}{\zeta(\theta)} \, \mathrm{d} \theta = - \frac{\pi}{\sqrt{r^2 + z^2}}.
        :label: int_1_over_zeta
 
-    It can be used to derived an alternative expression for the first term of :eq:`green_function_inf_depth_2`.
+The above lemma allows to retrieve the expression of the Green function found e.g. in [BD15]_:
+
+.. math::
+    \mathcal{G}(r, z) & = - \frac{1}{\sqrt{r^2 + z^2}} + \frac{2}{\pi} \Re \left( \int^{\pi/2}_{-\pi/2} \left( J(\zeta(r, z, \theta)) - \frac{1}{\zeta(r, z, \theta)} \right) \, \mathrm{d} \theta \right) \\
+    & \qquad \qquad \qquad \qquad + 2 i k \Re \left( \int^{\pi/2}_{-\pi/2} e^{\zeta (r, z, \theta)} \, \mathrm{d} \theta \right)
+    :label: green_function_inf_depth_del
 
 .. proof:lemma::
 
     The following identity holds [X18]_:
 
     .. math::
-        \Re \left( \int^{\pi/2}_{-\pi/2} e^{\zeta} \, \mathrm{d} \theta \right) = \pi \exp(k(x_3 + \xi_3)) J_0(k r)
+        \Re \left( \int^{\pi/2}_{-\pi/2} e^{\zeta} \, \mathrm{d} \theta \right) = \pi e^z J_0(r)
 
     where :math:`J_0` is the zeroth order Bessel function of the first kind.
 
 .. proof:lemma::
 
-    For any function :math:`f`, the following two formulations of the integral are equivalent:
+    For any function :math:`f`, the following two formulations of the integral are equivalent [Del89]_:
 
     .. math::
         \int_{-\frac{\pi}{2}}^{\frac{\pi}{2}} f \left(\zeta(\theta) \right) \mathrm{d} \theta =
@@ -286,65 +268,41 @@ Gradient of the Green function
 The gradient of the Green function can be written as
 
 .. math::
-   \nabla_x G(\xi, x) = - \frac{1}{4 \pi} \left( \nabla_x G_0(\xi, x) + \nabla_x G_1(\xi, x) + \nabla_x G_2(\xi, x) \right)
+   \nabla_x G(\xi, x) = - \frac{1}{4 \pi} \left( - \frac{x - \xi}{\|x - \xi\|^3} + k 
+      \begin{pmatrix}
+        \frac{\partial r}{\partial x_1} \frac{\partial \mathcal{G}}{\partial r} \\
+        \frac{\partial r}{\partial x_2} \frac{\partial \mathcal{G}}{\partial r} \\
+        \frac{\partial z}{\partial x_3} \frac{\partial \mathcal{G}}{\partial z}
+      \end{pmatrix}
+   \right)
 
-where
+with
 
 .. math::
-    \nabla_x G_0(\xi, x) = - \frac{x - \xi}{\|x - \xi\|^3}\,,
-    :label: green_function_inf_depth_deriv_0
+   \frac{\partial r}{\partial x_1} & = k \frac{x_1 - \xi_1}{r} \\
+   \frac{\partial r}{\partial x_2} & = k \frac{x_2 - \xi_2}{r} \\
+   \frac{\partial z}{\partial x_3} & = k
+
+and, using the identity :math:`J'(\zeta) = J(\zeta) - 1/\zeta`,
 
 .. math::
-    \nabla_x G_1(\xi, x) = \frac{x - s(\xi)}{\|x - s(\xi)\|^3}\,,
-    :label: green_function_inf_depth_deriv_1
+   \frac{\partial \mathcal{G}}{\partial r} = & - \frac{r}{(r^2 + z^2)^{3/2}} + \frac{2}{\pi} \Re \left( \int_{-\pi/2}^{\pi/2} i \cos(\theta) \left( J(\zeta) - \frac{1}{\zeta} \right) \, \mathrm{d}\theta \right) \\
+   & \qquad \qquad \qquad \qquad + 2 i \Re \left( \int^{\pi/2}_{-\pi/2} i \cos(\theta) e^{\zeta} \, \mathrm{d} \theta \right)
 
 and
 
 .. math::
-    \nabla_x G_2(\xi, x) = &
-    \frac{2 k}{\pi} \Re \left( \int^{\pi/2}_{-\pi/2} \left( J(\zeta(\theta)) - \frac{1}{\zeta(\theta)} \right) \, (\nabla_x \zeta) (\theta) \, \mathrm{d} \theta \right) \\
-    & - 2 \frac{x - s(\xi)}{\|x - s(\xi)\|^3}
-    + 2 i k \Re \left( \int^{\pi/2}_{-\pi/2} e^{\zeta (\theta)} \, (\nabla_x \zeta) (\theta) \, \mathrm{d} \theta \right) \\
-    :label: green_function_inf_depth_deriv_2
+   \frac{\partial \mathcal{G}}{\partial z} = & - \frac{z}{(r^2 + z^2)^{3/2}} + \frac{2}{\pi} \Re \left( \int_{-\pi/2}^{\pi/2} \left( J(\zeta) - \frac{1}{\zeta} \right) \, \mathrm{d}\theta \right) \\
+    & \qquad \qquad \qquad \qquad + 2 i \Re \left( \int^{\pi/2}_{-\pi/2} i \cos(\theta) e^{\zeta } \, \mathrm{d} \theta \right) \\
 
-where
+that is, using :numref:`Lemma {number} <integrate_one_over_zeta>`
 
 .. math::
-   :nowrap:
-
-   \[
-   (\nabla_x \zeta) (\theta) = k
-   \begin{pmatrix}
-   \frac{x_1 - \xi_1}{r} i \cos \theta \\
-   \frac{x_2 - \xi_2}{r} i \cos \theta \\
-   1
-   \end{pmatrix}.
-   \]
-
-.. proof:proof::
-
-    The derivation of :eq:`green_function_inf_depth_deriv_0` and :eq:`green_function_inf_depth_deriv_1` is straightforward.
-
-    Let us discuss the derivation of :eq:`green_function_inf_depth_deriv_2`. Using :numref:`Lemma {number} <integrate_one_over_zeta>`, the Green function :eq:`green_function_inf_depth_2` can be rewritten as:
-
-    .. math::
-        G_2(\xi, x) & =
-        \frac{2 k}{\pi} \Re \left( \int^{\pi/2}_{-\pi/2} J(\zeta(\theta)) \, \mathrm{d} \theta \right) + \frac{2}{\|x - s(\xi)\|} \\
-        & \qquad \qquad \qquad \qquad + 2 i k \Re \left( \int^{\pi/2}_{-\pi/2} e^{\zeta (\theta)} \, \mathrm{d} \theta \right)
+   \frac{\partial \mathcal{G}}{\partial z} = \mathcal{G}(r, z) + \frac{1}{\sqrt{r^2 + z^2}} - \frac{z}{(r^2 + z^2)^{3/2}}
+   :label: green_function_inf_depth_dGdz
 
 
-    Using the identity :math:`J'(\zeta) = J(\zeta) - 1/\zeta`, the first term of :eq:`green_function_inf_depth_deriv_2` can be derived.
-
-    .. math::
-        \nabla_x \left( \int^{\pi/2}_{-\pi/2} J(\zeta(\theta)) \, \mathrm{d} \theta \right) = \int^{\pi/2}_{-\pi/2} \left( J(\zeta(\theta)) - \frac{1}{\zeta(\theta)} \right) \, (\nabla_x \zeta) (\theta) \, \mathrm{d} \theta
-
-    The second term of :eq:`green_function_inf_depth_deriv_2` is similar to :eq:`green_function_inf_depth_deriv_1`.
-    Finally, the last term can be found as follows:
-
-    .. math::
-        \nabla_x \left( \int^{\pi/2}_{-\pi/2} e^{\zeta(\theta)} \, \mathrm{d} \theta \right) = \int^{\pi/2}_{-\pi/2} e^{\zeta(\theta)} \, (\nabla_x \zeta) (\theta) \, \mathrm{d} \theta
-
-.. note:: There is a typo in the second term of :eq:`green_function_inf_depth_deriv_2` in [Del89]_ and [BD15]_. It appears to be missing from [X18]_.
+.. ..note:: There seems to be a typo in the term of :eq:`green_function_inf_depth_deriv_2` in [Del89]_ and [BD15]_.
 
 .. note::
     The derivative of :math:`G` with respect to :math:`x_1` and :math:`x_2` are antisymmetric in the sense of
@@ -359,36 +317,65 @@ where
     Its derivative with respect to :math:`x_3` can be decomposed into an antisymmetric term and a symmetric term.
 
 
+Higher order derivative
+~~~~~~~~~~~~~~~~~~~~~~~
+
+From :eq:`green_function_inf_depth_dGdz`, one has
+
+.. math::
+   \frac{\partial \mathcal{G}}{\partial z} &= \mathcal{G}(r, z) + \left( 1 + \frac{\partial}{\partial z} \right) \frac{1}{\sqrt{r^2 + z^2}} \\
+   \frac{\partial^2 \mathcal{G}}{\partial z \partial r} &= \frac{\partial \mathcal{G}}{\partial r} + \left( \frac{\partial}{\partial r} + \frac{\partial^2}{\partial z \partial r} \right) \frac{1}{\sqrt{r^2 + z^2}}
+
+and
+
+.. math::
+   \frac{\partial^2 \mathcal{G}}{\partial z^2} &= \mathcal{G}(r, z) + \left( 1 + 2 \frac{\partial}{\partial z} + \frac{\partial^2}{\partial z^2} \right)\frac{1}{\sqrt{r^2 + z^2}} \\
+                                               &= \mathcal{G}(r, z) + \frac{1}{\sqrt{r^2 + z^2}} - 2 \frac{z}{(r^2 + z^2)^{3/2}} - \frac{r^2 - 2 z^2}{(r^2 + z^2)^{5/2}}
+
+Since the Green function is solution of the Laplace equation, it follows that
+
+.. math::
+   \frac{\partial^2 \mathcal{G}}{\partial r^2} + \frac{1}{r} \frac{\partial \mathcal{G}}{\partial r} + \frac{\partial^2 \mathcal{G}}{\partial z^2} = 0
+
+then
+
+.. math::
+   \frac{\partial^2 \mathcal{G}}{\partial r^2} = - \frac{1}{r} \frac{\partial \mathcal{G}}{\partial r} - \mathcal{G} - \left( 1 + 2 \frac{\partial}{\partial z} + \frac{\partial^2}{\partial z^2} \right)\frac{1}{\sqrt{r^2 + z^2}} \\
+
+All higher order derivative can be expressed with the help of :math:`\mathcal{G}` and :math:`\frac{\partial \mathcal{G}}{\partial r}`.
+
+.. note::
+   The same derivation is done in e.g. [N20]_ using instead the function :math:`F = \mathcal{G} - \frac{1}{\sqrt{r^2 + z^2}}` for which the expression are slightly simpler.
+
 Delhommeau's method for computation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The above formulations of the Green function and its derivative require the evaluation of the following real-valued integrals:
 
 .. math::
-    D_1(\tilde{r}, \tilde{z}) & = \Re \left( \int^{\pi/2}_{-\pi/2} - i \cos(\theta) \left( J(\zeta) - \frac{1}{\zeta} \right) \, \mathrm{d} \theta \right) \\
-    D_2(\tilde{r}, \tilde{z}) & = \Re \left( \int^{\pi/2}_{-\pi/2} - i \cos(\theta) e^{\zeta} \, \mathrm{d} \theta \right) \\
-    Z_1(\tilde{r}, \tilde{z}) & = \Re \left( \int^{\pi/2}_{-\pi/2} \left( J(\zeta) - \frac{1}{\zeta} \right) \, \mathrm{d} \theta \right) \\
-    Z_2(\tilde{r}, \tilde{z}) & = \Re \left( \int^{\pi/2}_{-\pi/2} e^{\zeta} \, \mathrm{d} \theta \right)
+    D_1(r, z) & = \Re \left( \int^{\pi/2}_{-\pi/2} - i \cos(\theta) \left( J(\zeta) - \frac{1}{\zeta} \right) \, \mathrm{d} \theta \right) \\
+    D_2(r, z) & = \Re \left( \int^{\pi/2}_{-\pi/2} - i \cos(\theta) e^{\zeta} \, \mathrm{d} \theta \right) \\
+    Z_1(r, z) & = \Re \left( \int^{\pi/2}_{-\pi/2} \left( J(\zeta) - \frac{1}{\zeta} \right) \, \mathrm{d} \theta \right) \\
+    Z_2(r, z) & = \Re \left( \int^{\pi/2}_{-\pi/2} e^{\zeta} \, \mathrm{d} \theta \right)
 
 
-where :math:`\tilde{r} = k r` and :math:`\tilde{z} = k (x_3 + \xi_3)`, such that :math:`\zeta = \tilde{z} + i \tilde{r} \cos \theta` and :math:`k \| x - s(\xi) \| = \sqrt{\tilde{r}^2 + \tilde{z}^2}`.
-
-To limit the computational cost of the evaluation of these integrals, they are precomputed for selected values of :math:`\tilde{r}` and :math:`\tilde{z}` and stored in a table.
+To limit the computational cost of the evaluation of these integrals, they are precomputed for selected values of :math:`r` and :math:`z` and stored in a table.
 When evaluating the Green function, the values of the integrals are retrieved by interpolating the values in the tables.
 
-For large values of :math:`\tilde{r}` and :math:`\tilde{z}`, these integrals are asymptotically approximated by the following expressions:
+For large values of :math:`r` and :math:`z`, these integrals are asymptotically approximated by the following expressions:
 
 .. math::
-      D_1(\tilde{r}, \tilde{z}) & \simeq \pi \exp(\tilde{z}) \sqrt{\frac{2\pi}{\tilde{r}}} \left(\cos(\tilde{r} - \pi/4) - \frac{1}{2\tilde{r}} \sin(\tilde{r}-\pi/4) \right) - \pi \frac{\tilde{r}}{\sqrt{\tilde{r}^2 + \tilde{z}^2}^3} \\
-      D_2(\tilde{r}, \tilde{z}) & \simeq \exp(\tilde{z}) \sqrt{\frac{2\pi}{\tilde{r}}} (\sin(\tilde{r} - \pi/4) + \frac{1}{2\tilde{r}} \cos(\tilde{r} - \pi/4)) \\
-      Z_1(\tilde{r}, \tilde{z}) & \simeq - \pi \exp(\tilde{z}) \sqrt{\frac{2\pi}{\tilde{r}}} \sin(\tilde{r} - \pi/4) + \pi \frac{\tilde{z}}{\sqrt{\tilde{r}^2 + \tilde{z}^2}^3} \\
-      Z_2(\tilde{r}, \tilde{z}) & \simeq \exp(\tilde{z}) \sqrt{\frac{2\pi}{\tilde{r}}} \cos(\tilde{r} - \pi/4)
+      D_1(r, z) & \simeq \pi e^z \sqrt{\frac{2\pi}{r}} \left(\cos(r - \pi/4) - \frac{1}{2r} \sin(r-\pi/4) \right) - \pi \frac{r}{(r^2 + z^2)^{3/2}} \\
+      D_2(r, z) & \simeq e^z \sqrt{\frac{2\pi}{r}} \left( \sin(r - \pi/4) + \frac{1}{2r} \cos(r - \pi/4) \right) \\
+      Z_1(r, z) & \simeq - \pi e^z \sqrt{\frac{2\pi}{r}} \sin(r - \pi/4) + \pi \frac{z}{(r^2 + z^2)^{3/2}} \\
+      Z_2(r, z) & \simeq e^z \sqrt{\frac{2\pi}{r}} \cos(r - \pi/4)
 
 
 Incorporating these asymptotic approximation in the expression of the Green function, one gets:
 
 .. math::
-    G_2(\xi, x) \simeq - 2 k \exp(\tilde{z}) \sqrt{\frac{2\pi}{\tilde{r}}} \left(\sin(\tilde{r} - \pi/4) - i\cos(\tilde{r} - \pi/4)\right) + 2 k \frac{\tilde{z}}{\sqrt{\tilde{r}^2 + \tilde{z}^2}^3}
+    \mathcal{G}(r, z) \simeq & -\frac{1}{\sqrt{r^2 + z^2}} - 2 k e^z \sqrt{\frac{2\pi}{r}} \left(\sin(r - \pi/4) - i\cos(r - \pi/4)\right) \\
+   & \qquad\qquad\qquad\qquad + 2 k \frac{z}{(r^2 + z^2)^{3/2}}
 
 
 Xie's variant
@@ -400,12 +387,12 @@ singularity :math:`\frac{1}{\zeta}`.
 Hence, they proposed to tabulate instead
 
 .. math::
-    \widetilde{Z_1}(\tilde{r}, \tilde{z}) = \Re \left( \int^{\pi/2}_{-\pi/2} J(\zeta) \, \mathrm{d} \theta \right)
+    \widetilde{Z_1}(r, z) = \Re \left( \int^{\pi/2}_{-\pi/2} J(\zeta) \, \mathrm{d} \theta \right)
 
 By using :numref:`Lemma {number} <integrate_one_over_zeta>`, one has
 
 .. math::
-   Z_1 = \widetilde{Z_1} - \frac{\pi}{k \sqrt{\tilde{r}^2 + \tilde{z}^2}}
+   Z_1 = \widetilde{Z_1} - \frac{\pi}{\sqrt{r^2 + z^2}}
 
 Both the original Delhommeau's method and Xie's variant are implemented in Capytaine.
 
@@ -426,7 +413,7 @@ TODO
 Symmetries
 ----------
 
-The first term of :eq:`green_function` is invariant under all rotations and translations, whereas the other terms are invariant under isometric transformations that don't change the vertical coordinate (reflection across a vertical plane, rotation around a vertical axis, translation following an horizontal vector).
+The first term of :eq:`green_function_inf_depth` is invariant under all rotations and translations, whereas the other terms are invariant under isometric transformations that don't change the vertical coordinate (reflection across a vertical plane, rotation around a vertical axis, translation following an horizontal vector).
 
 
 Discretization

--- a/pytest/test_bem_green_functions.py
+++ b/pytest/test_bem_green_functions.py
@@ -123,12 +123,3 @@ def test_symmetry_of_the_derivative_of_the_Green_function(X1, X2, omega, method)
                       wave_part_Green_function(X2, X1, omega, np.infty, method)[1][2],
                       rtol=1e-4)
 
-
-@given(points, points, frequencies)
-def test_compare_output_of_Delhommeau_and_XieDelhommeau(X1, X2, omega):
-    # Unchanged parts of the Green function:
-    assert np.allclose(
-            wave_part_Green_function(X1, X2, omega, np.infty, gfs[0])[1][0:2],
-            wave_part_Green_function(X1, X2, omega, np.infty, gfs[1])[1][0:2],
-            rtol=1e-5)
-


### PR DESCRIPTION
Since version 1.1, there are two implementations of the Green function available in Capytaine. The main one is `Delhommeau`, which is basically the same as in Nemoh. The other one is `XieDelhommeau`, which is a slight variant.
Their results are usually almost identical. However, I noticed that I wasn't making full use of the change introduced by `XieDelhommeau`.

In this PR, the implementation of `XieDelhommeau` has been changed to exploit the higher precision method for the singular parts of the Green function.

For most cases, it makes no visible difference. For some cases in infinite depth with horizontal panels close to the free surface, it leads to a large gain in accuracy, at no computational cost.
The example below is the result of the new `XieDelhommeau` for a sphere of radius 1 and center (0, 0, -1.01). The coarse mesh leads to results much closer to the fine mesh when the new `XieDelhommeau` method is used. The former `XieDelhommeau` was basically overlapped with `Delhommeau`.
![Example of result](https://user-images.githubusercontent.com/31126826/180212376-3ab816ed-7ef5-43aa-88f1-421a17f1a7a4.png)

Beside, another consequence of `XieDelhommeau` that wasn't exploited until now is a slight simplification of the code in finite depth (and maybe a marginal performance gain).

This PR also includes a revamp of the corresponding section of the documentation. The`XieDelhommeau` variant is actually slightly simpler to document and could become the base method in the future.