### PR TITLE
remove volume/area methods from pre-defined bodies.

### DIFF
--- a/capytaine/bodies/predefined/cylinders.py
+++ b/capytaine/bodies/predefined/cylinders.py
@@ -253,10 +253,6 @@ class HorizontalCylinder(FloatingBody):
 
             return cylinder
 
-    @property
-    def volume(self):
-        return self.length*np.pi*self.radius**2
-
 
 class VerticalCylinder(FloatingBody):
     """Vertical cylinder.
@@ -317,4 +313,3 @@ class VerticalCylinder(FloatingBody):
         mesh.name = f"{name}_mesh"
 
         FloatingBody.__init__(self, mesh=mesh, name=name)
-

--- a/capytaine/bodies/predefined/rectangles.py
+++ b/capytaine/bodies/predefined/rectangles.py
@@ -126,10 +126,6 @@ class Rectangle(FloatingBody):
 
         return mesh
 
-    @property
-    def area(self):
-        return self.size[0] * self.size[1]
-
 
 class RectangularParallelepiped(FloatingBody):
     """Six rectangles forming a parallelepiped.
@@ -291,13 +287,8 @@ class RectangularParallelepiped(FloatingBody):
         half_mesh = ReflectionSymmetricMesh(quarter_of_mesh, plane=yOz_Plane, name=f"half_of_{name}_mesh")
         return ReflectionSymmetricMesh(half_mesh, plane=xOz_Plane, name=f"{name}_mesh")
 
-    @property
-    def volume(self):
-        return np.product(self.size)
-
 
 class OpenRectangularParallelepiped(RectangularParallelepiped):
     def __init__(self, *args, **kwargs):
         RectangularParallelepiped.__init__(self, top=False, bottom=False, *args, **kwargs)
         # Kept mostly for legacy
-

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,16 @@ Changelog
    :depth: 1
    :backlinks: none
 
+---------------------------------
+New in version 1.4.1 (2022--)
+---------------------------------
+
+Bug fixes
+~~~~~~~~~
+
+* Removed outdated volume/area methods from pre-defined bodies (:pull:`183`).
+
+
 -------------------------------
 New in version 1.4 (2022-07-07)
 -------------------------------

--- a/pytest/test_bodies_predefined.py
+++ b/pytest/test_bodies_predefined.py
@@ -37,7 +37,6 @@ def test_rectangle_generation():
     assert all(rec.geometric_center == [0, 0, -5.0])
     assert rec.mesh.nb_faces == 12
     assert rec.mesh.nb_vertices == 21
-    assert rec.area == 100
 
     # x coordinate
     assert np.allclose(rec.mesh.vertices[:, 0], 0.0)
@@ -173,4 +172,3 @@ def test_sphere_clipping():
     assert s1.mesh.nb_faces == s2.mesh.nb_faces
     assert s1.mesh.nb_vertices == s2.mesh.nb_vertices
     # TODO: test that the faces are actually the same.
-


### PR DESCRIPTION
fixes #182