### PR TITLE
Raise error when calling `compute_hydrostatics()` without a center of mass

### DIFF
--- a/capytaine/bodies/bodies.py
+++ b/capytaine/bodies/bodies.py
@@ -674,9 +674,9 @@ respective inertia coefficients are assigned as NaN.")
         hydrostatics : dict
             All hydrostatics values of the FloatingBody.
         """
-        if not hasattr(self, "center_of_mass"):
-            LOG.warning("The floating body {} has no defined center of mass. The center of mass is set to (0,0,0).".format(self.name))
-            self.center_of_mass = np.array([0.0, 0.0, 0.0])
+        if self.center_of_mass is None:
+            raise ValueError(f"Trying to compute hydrostatics for {self.name}, but no center of mass has been defined.\n"
+                             f"Suggested solution: define a `center_of_mass` attribute for the FloatingBody {self.name}.")
 
         self.keep_immersed_part()
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,8 @@ New in version 1.4.2 (2022--)
 Bug fixes
 ~~~~~~~~~
 
+* Raise error message when calling :meth:`~capytaine.bodies.bodies.FloatingBody.compute_hydrostatics()` without a center of mass defined (:pull:`207`).
+
 * Fix bug when cropping body with a dof defined manually as a list of tuples (:issue:`204` and :pull:`206`).
 
 ---------------------------------


### PR DESCRIPTION
Cf. #204