### PR TITLE
Update installation instructions.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,8 @@ Documentation
 
 * The warning message for insufficient mesh resolution appears earlier and has been reworded to be clearer (:pull:`217`).
 
+* Update installation instructions (:pull:`219`)
+
 Internals
 ~~~~~~~~~
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,11 +21,11 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
+* Miscellaneous improvements of the documentation (:pull:`205`, :pull:`211`, :pull:`219`)
+
 * Clean up and fix animation example (:pull:`213`).
 
 * The warning message for insufficient mesh resolution appears earlier and has been reworded to be clearer (:pull:`217`).
-
-* Update installation instructions (:pull:`219`)
 
 Internals
 ~~~~~~~~~

--- a/docs/user_manual/installation.rst
+++ b/docs/user_manual/installation.rst
@@ -2,6 +2,13 @@
 Installation for users
 ======================
 
+Capytaine is available on Windows, MacOS [#]_ and Linux.
+
+.. [#] For the latest informations on the arm64 architectures (Apple M1), see https://github.com/capytaine/capytaine/issues/190
+
+Capytaine requires Python 3.6 or higher.
+Thus it is compatible with `all currently supported version of Python <https://devguide.python.org/versions/>`_.
+
 With Conda
 ----------
 
@@ -13,9 +20,8 @@ Download and install the `Anaconda distribution`_ or its lightweight counterpart
 .. _Miniconda: https://conda.io/miniconda.html
 .. _Miniforge: https://github.com/conda-forge/miniforge
 
-Capytaine requires **Python 3.6** or higher.
-
-Once Conda has been installed, run the following command in a terminal to install Capytaine::
+Once Conda has been installed, you might want to `create a dedicated environment <https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments>`_.
+Capytaine's package is available in the `conda-forge` channel and can be installed with the following command ::
 
     conda install -c conda-forge capytaine
 
@@ -51,7 +57,6 @@ The package is available on PyPI, although only as a source distribution.
 That means that you'll need a Fortran compiler [#]_ in order to install the package.
 If you do, you can install Capytaine as::
 
-    pip install numpy
     pip install capytaine
 
 If you can't install a compiler, it is recommended to use Conda instead.


### PR DESCRIPTION
Add a reference to #190.
Also, since #170, I don't think installing numpy is required to install Capytaine with pip.