### PR TITLE
__rmatmul__ for low rank matrices

### DIFF
--- a/capytaine/matrices/low_rank.py
+++ b/capytaine/matrices/low_rank.py
@@ -376,6 +376,14 @@ class LowRankMatrix:
     def _mul_with_vector(self, other):
         return self.left_matrix @ (self.right_matrix @ other)
 
+    def __rmatmul__(self, other):
+        if isinstance(other, np.ndarray) and len(other.shape) == 1:
+            return self._rmul_with_vector(other)
+        else:
+            return NotImplemented
+
+    def _rmul_with_vector(self, other):
+        return (other @ self.left_matrix) @ self.right_matrix
+
     def astype(self, dtype):
         return LowRankMatrix(self.left_matrix.astype(dtype), self.right_matrix.astype(dtype))
-

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ Internals
 
 * The integration of the pressure on the mesh of the body was implemented twice independently. It has been factored out in :meth:`~capytaine.bodies.bodies.FloatingBody.integrate_pressure` (:pull:`218`)
 
+* `__rmatmul__` has been implemented for low rank matrices (:pull:`222`). 
+
 ---------------------------------
 New in version 1.4.2 (2022-10-03)
 ---------------------------------

--- a/pytest/test_matrices.py
+++ b/pytest/test_matrices.py
@@ -561,7 +561,7 @@ def test_rmatvec_lowrank():
 
     v = np.ones(3)
 
-    M_lowrank = cpt.matrices.LowRankMatrix(left_matrix, right_matrix)
+    M_lowrank = LowRankMatrix(left_matrix, right_matrix)
     M_full = left_matrix@right_matrix
 
     vM_lowrank = M_lowrank.__rmatmul__(v)

--- a/pytest/test_matrices.py
+++ b/pytest/test_matrices.py
@@ -554,4 +554,17 @@ def test_hierarchical_matrix():
     doubled = HS + HS
     assert np.allclose(2*S, doubled.full_matrix(), rtol=2e-1)
 
+def test_rmatvec_lowrank():
 
+    left_matrix = np.arange(6).reshape((3,2))
+    right_matrix = np.arange(8).reshape((2,4))
+
+    v = np.ones(3)
+
+    M_lowrank = cpt.matrices.LowRankMatrix(left_matrix, right_matrix)
+    M_full = left_matrix@right_matrix
+
+    vM_lowrank = M_lowrank.__rmatmul__(v)
+    vM_full = v @ M_full
+
+    assert np.all(vM_lowrank==vM_full)


### PR DESCRIPTION
Implemented __rmatmul__ for low rank matrices: if v is a vector and M is a low rank matrix, vM can be computed as M.__rmatmul__(v). 