### PR TITLE
Change floating point precision of the Green function from Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test: develop
 	python -m pytest
 
 clean:
-	rm -f capytaine/green_functions/*.so
+	rm -f capytaine/green_functions/libs/*.so
 	rm -rf build/
 	rm -rf dist/
 	rm -rf capytaine.egg-info/

--- a/capytaine/__init__.py
+++ b/capytaine/__init__.py
@@ -20,7 +20,7 @@ from capytaine.bodies.predefined.rectangles import Rectangle, RectangularParalle
 from capytaine.bem.problems_and_results import RadiationProblem, DiffractionProblem
 from capytaine.bem.solver import Nemoh, BEMSolver
 from capytaine.bem.engines import BasicMatrixEngine, HierarchicalToeplitzMatrixEngine
-from capytaine.green_functions.delhommeau import Delhommeau, XieDelhommeau, UntabulatedDelhommeau
+from capytaine.green_functions.delhommeau import Delhommeau, XieDelhommeau
 
 from capytaine.post_pro.free_surfaces import FreeSurface
 

--- a/capytaine/__init__.py
+++ b/capytaine/__init__.py
@@ -20,7 +20,7 @@ from capytaine.bodies.predefined.rectangles import Rectangle, RectangularParalle
 from capytaine.bem.problems_and_results import RadiationProblem, DiffractionProblem
 from capytaine.bem.solver import Nemoh, BEMSolver
 from capytaine.bem.engines import BasicMatrixEngine, HierarchicalToeplitzMatrixEngine
-from capytaine.green_functions.delhommeau import Delhommeau, XieDelhommeau
+from capytaine.green_functions.delhommeau import Delhommeau, XieDelhommeau, UntabulatedDelhommeau
 
 from capytaine.post_pro.free_surfaces import FreeSurface
 

--- a/capytaine/green_functions/delhommeau.py
+++ b/capytaine/green_functions/delhommeau.py
@@ -35,13 +35,16 @@ class Delhommeau(AbstractGreenFunction):
         The implementation of the Prony decomposition used to compute the finite depth Green function.
         Accepted values: :code:`'fortran'` for Nemoh's implementation (by default), :code:`'python'` for an experimental Python implementation.
         See :func:`find_best_exponential_decomposition`.
+    floating_point_precision: string, optional
+        Either :code:`'float32'` for single precision computations or :code:`'float64'` for double precision computations.
+        Default: :code:`'float64'`.
 
     Attributes
     ----------
-    tabulated_r_range: numpy.array of shape(tabulation_nr,)
-    tabulated_z_range: numpy.array of shape(tabulation_nz,)
+    tabulated_r_range: numpy.array of shape (tabulation_nr,) and type floating_point_precision
+    tabulated_z_range: numpy.array of shape (tabulation_nz,) and type floating_point_precision
         Coordinates of the tabulation points.
-    tabulated_integrals: numpy.array of shape (tabulation_nr, tabulation_nz, 2, 2)
+    tabulated_integrals: numpy.array of shape (tabulation_nr, tabulation_nz, 2, 2) and type floating_point_precision
         Tabulated Delhommeau integrals.
     """
 
@@ -52,7 +55,7 @@ class Delhommeau(AbstractGreenFunction):
                  tabulation_nz=46,
                  tabulation_nb_integration_points=251,
                  finite_depth_prony_decomposition_method='fortran',
-                 floating_point_precision="float64",
+                 floating_point_precision='float64',
                  ):
 
         self.fortran_core = import_module(f"capytaine.green_functions.libs.{self.fortran_core_basename}_{floating_point_precision}")

--- a/capytaine/green_functions/delhommeau.py
+++ b/capytaine/green_functions/delhommeau.py
@@ -228,11 +228,3 @@ class XieDelhommeau(Delhommeau):
     """
 
     fortran_core_basename = "XieDelhommeau"
-
-class UntabulatedDelhommeau(Delhommeau):
-    """Variant of Nemoh's Green function without tabulation.
-
-    Same arguments and methods as :class:`Delhommeau`.
-    """
-
-    fortran_core_basename = "UntabulatedDelhommeau"

--- a/capytaine/green_functions/delhommeau.py
+++ b/capytaine/green_functions/delhommeau.py
@@ -71,6 +71,7 @@ class Delhommeau(AbstractGreenFunction):
             'tabulation_nz': tabulation_nz,
             'tabulation_nb_integration_points': tabulation_nb_integration_points,
             'finite_depth_prony_decomposition_method': finite_depth_prony_decomposition_method,
+            'floating_point_precision': floating_point_precision,
         }
 
         self._hash = hash(self.exportable_settings.values())

--- a/capytaine/green_functions/delhommeau.py
+++ b/capytaine/green_functions/delhommeau.py
@@ -12,8 +12,7 @@ import numpy as np
 from capytaine.tools.prony_decomposition import exponential_decomposition, error_exponential_decomposition
 
 from capytaine.green_functions.abstract_green_function import AbstractGreenFunction
-import capytaine.green_functions.Delhommeau_f90 as Delhommeau_f90
-import capytaine.green_functions.XieDelhommeau_f90 as XieDelhommeau_f90
+from capytaine.green_functions import Delhommeau_f90, XieDelhommeau_f90, UntabulatedDelhommeau_f90
 
 LOG = logging.getLogger(__name__)
 
@@ -225,3 +224,11 @@ class XieDelhommeau(Delhommeau):
     """
 
     fortran_core = XieDelhommeau_f90
+
+class UntabulatedDelhommeau(Delhommeau):
+    """Variant of Nemoh's Green function without tabulation.
+
+    Same arguments and methods as :class:`Delhommeau`.
+    """
+
+    fortran_core = UntabulatedDelhommeau_f90

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,8 @@ Major changes
   A missing key element has been added and the :class:`~capytaine.green_functions.delhommeau.XieDelhommeau` is now actually more accurate near the free surface.
   (:pull:`180` and :pull:`216`)
 
+* Add `floating_point_precision` argument to :meth:`~capytaine.green_functions.delhommeau.Delhommeau` and :meth:`~capytaine.green_functions.delhommeau.XieDelhommeau` that accepts either `float32` for single precision computations or `float64` for double precision computations (the latter is the default). (:pull:`224`).
+
 Internals
 ~~~~~~~~~
 

--- a/pytest/test_bem_green_functions.py
+++ b/pytest/test_bem_green_functions.py
@@ -124,3 +124,6 @@ def test_symmetry_of_the_derivative_of_the_Green_function(X1, X2, omega, method)
                       rtol=1e-4)
 
 
+def test_floating_point_precision():
+    assert Delhommeau(floating_point_precision="float64").tabulated_integrals.dtype == np.float64
+    assert Delhommeau(floating_point_precision="float32").tabulated_integrals.dtype == np.float32

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from numpy.distutils.core import Extension, setup
 #  Fortran extensions  #
 ########################
 
-Delhommeau_source = [
+libDelhommeau_source_files = [
         "capytaine/green_functions/libDelhommeau/src/constants.f90",
         "capytaine/green_functions/libDelhommeau/src/Delhommeau_integrals.f90",
         "capytaine/green_functions/libDelhommeau/src/old_Prony_decomposition.f90",
@@ -21,29 +21,31 @@ Delhommeau_source = [
         "capytaine/green_functions/libDelhommeau/src/matrices.f90",
     ]
 
-Delhommeau_extension = Extension(
-    name="capytaine.green_functions.Delhommeau_f90",
-    sources=Delhommeau_source,
-    extra_f90_compile_args=['-O2', '-fopenmp', '-cpp'],
-    extra_link_args=['-fopenmp'],
-    # # Uncomment the following lines to get more verbose output from f2py.
-    # define_macros=[
-    #     ('F2PY_REPORT_ATEXIT', 1),
-    #     ('F2PY_REPORT_ON_ARRAY_COPY', 1),
-    # ],
-)
-
-XieDelhommeau_extension = Extension(
-    name="capytaine.green_functions.XieDelhommeau_f90",
-    sources=Delhommeau_source,
-    extra_f90_compile_args=['-O2', '-fopenmp', '-cpp', '-DXIE_CORRECTION'],
-    extra_link_args=['-fopenmp'],
-    # # Uncomment the following lines to get more verbose output from f2py.
-    # define_macros=[
-    #     ('F2PY_REPORT_ATEXIT', 1),
-    #     ('F2PY_REPORT_ON_ARRAY_COPY', 1),
-    # ],
-)
+extensions_modules = [
+        Extension(
+            name="capytaine.green_functions.Delhommeau_f90",
+            sources=libDelhommeau_source_files,
+            extra_f90_compile_args=['-O2', '-fopenmp', '-cpp'],
+            extra_link_args=['-fopenmp'],
+            # # Uncomment the following lines to get more verbose output from f2py.
+            # define_macros=[
+                #     ('F2PY_REPORT_ATEXIT', 1),
+                #     ('F2PY_REPORT_ON_ARRAY_COPY', 1),
+                # ],
+            ),
+        Extension(
+            name="capytaine.green_functions.XieDelhommeau_f90",
+            sources=libDelhommeau_source_files,
+            extra_f90_compile_args=['-O2', '-fopenmp', '-cpp', '-DXIE_CORRECTION'],
+            extra_link_args=['-fopenmp'],
+            ),
+        Extension(
+            name="capytaine.green_functions.UntabulatedDelhommeau_f90",
+            sources=libDelhommeau_source_files,
+            extra_f90_compile_args=['-O2', '-fopenmp', '-cpp', '-DXIE_CORRECTION', '-DNO_TABULATION'],
+            extra_link_args=['-fopenmp'],
+            ),
+        ]
 
 
 ########################################################
@@ -123,8 +125,5 @@ if __name__ == "__main__":
                   'capytaine=capytaine.ui.cli:main',
               ],
           },
-          ext_modules=[
-              Delhommeau_extension,
-              XieDelhommeau_extension,
-          ],
-          )
+          ext_modules=extensions_modules,
+      )

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ def libDelhommeau_src(precision):
 extensions_names_and_extra_arguments = [
         ("capytaine.green_functions.libs.Delhommeau", []),
         ("capytaine.green_functions.libs.XieDelhommeau", ["-DXIE_CORRECTION"]),
-        ("capytaine.green_functions.libs.UntabulatedDelhommeau", ["-DNO_TABULATION", "-DXIE_CORRECTION"]),
         ]
 
 extensions_modules = [

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@ from numpy.distutils.core import Extension, setup
 #  Fortran extensions  #
 ########################
 
-libDelhommeau_source_files = [
+def libDelhommeau_src(precision):
+    return [
+        "capytaine/green_functions/libDelhommeau/src/{}.f90".format(precision),
         "capytaine/green_functions/libDelhommeau/src/constants.f90",
         "capytaine/green_functions/libDelhommeau/src/Delhommeau_integrals.f90",
         "capytaine/green_functions/libDelhommeau/src/old_Prony_decomposition.f90",
@@ -21,32 +23,27 @@ libDelhommeau_source_files = [
         "capytaine/green_functions/libDelhommeau/src/matrices.f90",
     ]
 
+extensions_names_and_extra_arguments = [
+        ("capytaine.green_functions.libs.Delhommeau", []),
+        ("capytaine.green_functions.libs.XieDelhommeau", ["-DXIE_CORRECTION"]),
+        ("capytaine.green_functions.libs.UntabulatedDelhommeau", ["-DNO_TABULATION", "-DXIE_CORRECTION"]),
+        ]
+
 extensions_modules = [
         Extension(
-            name="capytaine.green_functions.Delhommeau_f90",
-            sources=libDelhommeau_source_files,
-            extra_f90_compile_args=['-O2', '-fopenmp', '-cpp'],
+            name=name + "_" + precision,
+            sources=libDelhommeau_src(precision),
+            extra_f90_compile_args=['-fopenmp', '-cpp'] + extra_args,
             extra_link_args=['-fopenmp'],
             # # Uncomment the following lines to get more verbose output from f2py.
             # define_macros=[
-                #     ('F2PY_REPORT_ATEXIT', 1),
-                #     ('F2PY_REPORT_ON_ARRAY_COPY', 1),
-                # ],
-            ),
-        Extension(
-            name="capytaine.green_functions.XieDelhommeau_f90",
-            sources=libDelhommeau_source_files,
-            extra_f90_compile_args=['-O2', '-fopenmp', '-cpp', '-DXIE_CORRECTION'],
-            extra_link_args=['-fopenmp'],
-            ),
-        Extension(
-            name="capytaine.green_functions.UntabulatedDelhommeau_f90",
-            sources=libDelhommeau_source_files,
-            extra_f90_compile_args=['-O2', '-fopenmp', '-cpp', '-DXIE_CORRECTION', '-DNO_TABULATION'],
-            extra_link_args=['-fopenmp'],
-            ),
+            #     ('F2PY_REPORT_ATEXIT', 1),
+            #     ('F2PY_REPORT_ON_ARRAY_COPY', 1),
+            # ],
+        )
+        for (name, extra_args) in extensions_names_and_extra_arguments
+        for precision in ["float32", "float64"]
         ]
-
 
 ########################################################
 #  Read version number and other info in __about__.py  #


### PR DESCRIPTION
### Single precision versions

The Green functions now have a `floating_point_precision` argument that can be set to `float32` for single precision computation (default is still `float64`).

TODO: compare performance and memory usage of the single precision version.

#### Some comments on the implementation

The Fortran source code is compiled twice, once for each precision.

My first try to select a precision was to use the compiler's preprocessor:
```
#ifdef SINGLE_PRECISION
  integer, parameter :: pre = kind(1e0)
#else
  integer, parameter :: pre = kind(1d0)
#endif
  real(kind=pre) :: blablabla
```
It works well as a standalone, but f2py is not aware of the preprocessor and is always using the first definition of `pre`. Thus f2py is failing to infer the correct type signature for all functions and to bind the Fortran code to Python.

After some desperate efforst to configure f2py, I found another way that is still relatively straightforward: putting `pre` in its own module `floating_point_precision` and having two files `float32.f90` and `float64.f90` implementing two variants of the same module. Depending of the version of `floating_point_precision` that is included in the list of source files, the compiled code will be single or double precision. And f2py is now able to automatically infer the signatures of all functions.

### Untabulated Green function

Edit: I changed my mind and I will not include the untabulated Green function in this PR. There might be a nicer way to do that and this PR is big enough already.