### PR TITLE
Replace direct solver by LU decomposition with cache

### DIFF
--- a/capytaine/bem/engines.py
+++ b/capytaine/bem/engines.py
@@ -59,9 +59,11 @@ class BasicMatrixEngine(MatrixEngine):
     """
 
     available_linear_solvers = {'direct': linear_solvers.solve_directly,
-                                'gmres': linear_solvers.solve_gmres}
+                                'lu_decomposition': linear_solvers.LUSolverWithCache().solve,
+                                'gmres': linear_solvers.solve_gmres,
+                                }
 
-    def __init__(self, *, linear_solver='direct', matrix_cache_size=1):
+    def __init__(self, *, linear_solver='lu_decomposition', matrix_cache_size=1):
 
         if linear_solver in self.available_linear_solvers:
             self.linear_solver = self.available_linear_solvers[linear_solver]

--- a/capytaine/matrices/linear_solvers.py
+++ b/capytaine/matrices/linear_solvers.py
@@ -60,16 +60,56 @@ def solve_directly(A, b):
         raise ValueError(f"Unrecognized type of matrix to solve: {A}")
 
 
-# EXPERIMENT: STORING THE LU DECOMPOSITION
-@lru_cache(maxsize=1)
-def lu_decomp(A):
-    LOG.debug(f"Compute LU decomposition of {A}.")
-    return sl.lu_factor(A.full_matrix())
+# CACHED LU DECOMPOSITION
+class LUSolverWithCache:
+    """Solve linear system with the LU decomposition.
 
+    The latest LU decomposition is kept in memory, if a system with the same matrix needs to be solved again, then the decomposition is reused.
 
-def solve_storing_lu(A, b):
-    LOG.debug(f"Solve with LU decomposition of {A}.")
-    return sl.lu_solve(lu_decomp(A), b)
+    Most of the complexity of this class comes from:
+    1. @lru_cache does not work because numpy arrays are not hashable. So a basic cache system has been recoded from scratch.
+    2. To be the default solver for the BasicMatrixEngine, the solver needs to support matrices for problems with one or two reflection symmetries.
+       Hence, a custom way to cache the LU decomposition of the matrices involved in the direct linear resolution of the symmetric problem.
+    """
+    def __init__(self):
+        self.cached_matrix = None
+        self.cached_decomp = None
+
+    def solve(self, A, b):
+        return self.solve_with_decomp(self.cached_lu_decomp(A), b)
+
+    def lu_decomp(self, A):
+        """Return the LU decomposition of A.
+        If A is BlockSymmetricToeplitzMatrix, then return a list of LU decompositions for each block of the block diagonalisation of the matrix.
+        """
+        if isinstance(A, BlockSymmetricToeplitzMatrix) and A.nb_blocks == (2, 2):
+            A1, A2 = A._stored_blocks[0, :]
+            return [self.lu_decomp(A1 + A2), self.lu_decomp(A1 - A2)]
+        elif isinstance(A, np.ndarray):
+            return sl.lu_factor(A)
+        else:
+            raise NotImplementedError("Cached LU solver is only implemented for dense matrices and 2×2 BlockSymmetricToeplitzMatrix.")
+
+    def cached_lu_decomp(self, A):
+        if not(A is self.cached_matrix):
+            self.cached_matrix = A
+            self.cached_decomp = self.lu_decomp(A)
+        return self.cached_decomp
+
+    def solve_with_decomp(self, decomp, b):
+        """Solve the system using the precomputed LU decomposition.
+        TODO: find a better way to differentiate a LU decomposition (returned as tuple by sl.lu_factor)
+        and a set of LU decomposition (stored as a list in self.lu_decomp).
+        """
+        if isinstance(decomp, list):  # The matrix was a BlockSymmetricToeplitzMatrix
+            b1, b2 = b[:len(b)//2], b[len(b)//2:]
+            x_plus = self.solve_with_decomp(decomp[0], b1 + b2)
+            x_minus = self.solve_with_decomp(decomp[1], b1 - b2)
+            return np.concatenate([x_plus + x_minus, x_plus - x_minus])/2
+        elif isinstance(decomp, tuple):  # The matrix was a np.ndarray
+            return sl.lu_solve(decomp, b)
+        else:
+            raise NotImplementedError("Cached LU solver is only implemented for dense matrices and 2×2 BlockSymmetricToeplitzMatrix.")
 
 
 # ITERATIVE SOLVER

--- a/capytaine/matrices/linear_solvers.py
+++ b/capytaine/matrices/linear_solvers.py
@@ -93,7 +93,10 @@ class LUSolverWithCache:
     def cached_lu_decomp(self, A):
         if not(A is self.cached_matrix):
             self.cached_matrix = A
+            LOG.debug(f"Computing and caching LU decomposition")
             self.cached_decomp = self.lu_decomp(A)
+        else:
+            LOG.debug(f"Using cached LU decomposition")
         return self.cached_decomp
 
     def solve_with_decomp(self, decomp, b):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,8 @@ Major changes
   A missing key element has been added and the :class:`~capytaine.green_functions.delhommeau.XieDelhommeau` is now actually more accurate near the free surface.
   (:pull:`180` and :pull:`216`)
 
+* New default linear solver :class:`~capytaine.matrices.linear_solvers.LUSolverWithCache`: the LU decomposition of the matrix is now cached to be reused for other similar problems, diminishing the total computation time up to 40%. (:pull:`235`)
+
 Minor changes
 ~~~~~~~~~~~~~
 

--- a/docs/user_manual/resolution.rst
+++ b/docs/user_manual/resolution.rst
@@ -45,12 +45,14 @@ Two of them are available in the present version:
            Setting it to :code:`0` will reduce the RAM usage of the code but might
            increase the computation time.
 
-   :code:`linear_solver` (Default: :code:`'direct'`)
+   :code:`linear_solver` (Default: :code:`'lu_decomposition'`)
            This option is used to set the solver for linear systems that is used in the resolution of the BEM problem.
-           Passing a string will make the code use one of the predefined solver. Two of them are available:
-           :code:`'direct'` for a direct solver using LU-decomposition or :code:`'gmres'` for an iterative solver.
+           Passing a string will make the code use one of the predefined solver. Three of them are available:
+           :code:`'direct'` for a simple direct solver,
+           :code:`'lu_decomposition'` for a faster direct solver with caching of the LU decomposition,
+           or :code:`'gmres'` for an iterative solver.
 
-           The former is used by default (since version 1.4) because it is more robust and the computation time is more predictable.
+           A direct solver is used by default (since version 1.4) because it is more robust and the computation time is more predictable.
            Advanced users might want to change the solver to :code:`gmres`, which is faster in many situations (and completely fails in other).
 
            Alternatively, any function taking as arguments a matrix and a vector and returning a vector can be given to the solver::

--- a/pytest/test_bem_solver.py
+++ b/pytest/test_bem_solver.py
@@ -32,7 +32,7 @@ def test_exportable_settings():
     engine = BasicMatrixEngine(matrix_cache_size=0)
     assert engine.exportable_settings['engine'] == 'BasicMatrixEngine'
     assert engine.exportable_settings['matrix_cache_size'] == 0
-    assert engine.exportable_settings['linear_solver'] == 'direct'
+    assert engine.exportable_settings['linear_solver'] == 'lu_decomposition'
 
     solver = BEMSolver(green_function=gf, engine=engine)
     assert solver.exportable_settings['green_function'] == 'Delhommeau'
@@ -40,7 +40,7 @@ def test_exportable_settings():
     assert solver.exportable_settings['finite_depth_prony_decomposition_method'] == 'fortran'
     assert solver.exportable_settings['engine'] == 'BasicMatrixEngine'
     assert solver.exportable_settings['matrix_cache_size'] == 0
-    assert solver.exportable_settings['linear_solver'] == 'direct'
+    assert solver.exportable_settings['linear_solver'] == 'lu_decomposition'
 
 
 def test_limit_frequencies():

--- a/pytest/test_linear_solvers.py
+++ b/pytest/test_linear_solvers.py
@@ -1,0 +1,170 @@
+import pytest
+import numpy as np
+import capytaine as cpt
+
+from capytaine.matrices.block_toeplitz import BlockSymmetricToeplitzMatrix, BlockCirculantMatrix, BlockToeplitzMatrix
+from capytaine.matrices.builders import random_block_matrix
+from capytaine.matrices.linear_solvers import solve_directly, LUSolverWithCache, solve_gmres
+
+#######################################################################
+#                            Full problems                            #
+#######################################################################
+
+@pytest.fixture
+def solved_full_problem():
+    A = np.random.rand(5, 5)
+    x = np.random.rand(A.shape[0])
+    return (A, x, A @ x)
+
+def test_solve_directly_full_problem(solved_full_problem):
+    A, x_ref, b = solved_full_problem
+    x = solve_directly(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+
+def test_solve_with_lu_full_problem(solved_full_problem):
+    A, x_ref, b = solved_full_problem
+    linear_solver = LUSolverWithCache()
+    x = linear_solver.solve(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+    x = linear_solver.solve(A, b)  # Should use cache
+    assert np.allclose(x, x_ref, rtol=1e-10)
+
+def test_gmres_full_problem(solved_full_problem):
+    A, x_ref, b = solved_full_problem
+    x = solve_gmres(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+
+#######################################################################
+#           2x2 block symmetric matrices (reflection mesh)            #
+#######################################################################
+
+@pytest.fixture
+def solved_2x2_block_symmetric_toeplitz_problem():
+    A = BlockSymmetricToeplitzMatrix([
+        [np.random.rand(4, 4) for _ in range(2)]
+    ])
+    x = np.random.rand(A.shape[0])
+    return (A, x, A @ x)
+
+def test_solve_directly_2x2_block_symmetric_toeplitz_problem(solved_2x2_block_symmetric_toeplitz_problem):
+    A, x_ref, b = solved_2x2_block_symmetric_toeplitz_problem
+    x = solve_directly(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+
+def test_solve_with_lu_2x2_block_symmetric_toeplitz_problem(solved_2x2_block_symmetric_toeplitz_problem):
+    A, x_ref, b = solved_2x2_block_symmetric_toeplitz_problem
+    linear_solver = LUSolverWithCache()
+    x = linear_solver.solve(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+    x = linear_solver.solve(A, b)  # Should use cache
+    assert np.allclose(x, x_ref, rtol=1e-10)
+
+def test_gmres_2x2_block_symmetric_toeplitz_problem(solved_2x2_block_symmetric_toeplitz_problem):
+    A, x_ref, b = solved_2x2_block_symmetric_toeplitz_problem
+    x = solve_gmres(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+
+#######################################################################
+#       Nested 2x2 block symmetric matrices (two reflections)         #
+#######################################################################
+
+@pytest.fixture
+def solved_nested_2x2_block_symmetric_toeplitz_problem():
+    A = BlockSymmetricToeplitzMatrix([
+        [BlockSymmetricToeplitzMatrix([
+            [np.random.rand(4, 4) for _ in range(2)]
+            ]) for _ in range(2)]
+        ])
+    x = np.random.rand(A.shape[0])
+    return (A, x, A @ x)
+
+def test_solve_directly_nested_2x2_block_symmetric_toeplitz_problem(solved_nested_2x2_block_symmetric_toeplitz_problem):
+    A, x_ref, b = solved_nested_2x2_block_symmetric_toeplitz_problem
+    x = solve_directly(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+
+def test_solve_with_lu_nested_2x2_block_symmetric_toeplitz_problem(solved_nested_2x2_block_symmetric_toeplitz_problem):
+    A, x_ref, b = solved_nested_2x2_block_symmetric_toeplitz_problem
+    linear_solver = LUSolverWithCache()
+    x = linear_solver.solve(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+    x = linear_solver.solve(A, b)  # Should use cache
+    assert np.allclose(x, x_ref, rtol=1e-10)
+
+def test_gmres_2x2_nested_block_symmetric_toeplitz_problem(solved_nested_2x2_block_symmetric_toeplitz_problem):
+    A, x_ref, b = solved_nested_2x2_block_symmetric_toeplitz_problem
+    x = solve_gmres(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+
+#######################################################################
+#                           Block circulant                           #
+#######################################################################
+
+@pytest.fixture
+def solved_block_circulant_problem():
+    A = BlockCirculantMatrix([
+        [np.random.rand(3, 3) for _ in range(6)]
+    ])
+    x = np.random.rand(A.shape[0])
+    return (A, x, A @ x)
+
+def test_solve_directly_block_circulant_problem(solved_block_circulant_problem):
+    A, x_ref, b = solved_block_circulant_problem
+    x = solve_directly(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+
+def test_solve_with_lu_block_circulant_problem(solved_block_circulant_problem):
+    A, x_ref, b = solved_block_circulant_problem
+    linear_solver = LUSolverWithCache()
+    with pytest.raises(NotImplementedError):
+        x = linear_solver.solve(A, b)
+
+def test_gmres_block_circulant_problem(solved_block_circulant_problem):
+    A, x_ref, b = solved_block_circulant_problem
+    x = solve_gmres(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+
+
+#######################################################################
+#                           Block Toeplitz                            #
+#######################################################################
+@pytest.fixture
+def solved_block_toeplitz_problem():
+    A = BlockToeplitzMatrix([
+        [np.random.rand(3, 3) for _ in range(7)]
+    ])
+    x = np.random.rand(A.shape[0])
+    return (A, x, A @ x)
+
+def test_solve_directly_block_toeplitz_problem(solved_block_toeplitz_problem):
+    A, x_ref, b = solved_block_toeplitz_problem
+    x = solve_directly(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+
+def test_gmres_block_toeplitz_problem(solved_block_toeplitz_problem):
+    A, x_ref, b = solved_block_toeplitz_problem
+    x = solve_gmres(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+
+
+#######################################################################
+#                            Nested blocks                            #
+#######################################################################
+@pytest.fixture
+def solved_nested_block_problem():
+    A = BlockCirculantMatrix([
+        [random_block_matrix([1, 1], [1, 1]) for _ in range(6)]
+    ])
+    x = np.random.rand(A.shape[0])
+    return (A, x, A @ x)
+
+def test_solve_directly_nested_block_problem(solved_nested_block_problem):
+    A, x_ref, b = solved_nested_block_problem
+    x = solve_directly(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+
+def test_gmres_block_toeplitz_problem(solved_nested_block_problem):
+    A, x_ref, b = solved_nested_block_problem
+    x = solve_gmres(A, b)
+    assert np.allclose(x, x_ref, rtol=1e-10)
+

--- a/pytest/test_matrices.py
+++ b/pytest/test_matrices.py
@@ -12,7 +12,6 @@ from capytaine.matrices.block import BlockMatrix
 from capytaine.matrices.block_toeplitz import *
 from capytaine.matrices.builders import *
 from capytaine.matrices.low_rank import LowRankMatrix, NoConvergenceOfACA
-from capytaine.matrices.linear_solvers import solve_directly, solve_gmres
 
 try:
     import matplotlib.pyplot as plt
@@ -373,67 +372,6 @@ def test_complex_valued_matrices():
     B = EvenBlockSymmetricCirculantMatrix([[A.full_matrix(), 2*A.full_matrix()]])
     c = np.random.rand(B.shape[1]) + 1j * np.random.rand(B.shape[1])
     assert np.allclose(B @ c, B.full_matrix() @ c)
-    # assert np.allclose(solve_directly(B, c), solve_directly(B.full_matrix(), c))
-
-
-def test_solve_2x2():
-    # 2x2 blocks
-    A = BlockSymmetricToeplitzMatrix([
-        [np.random.rand(3, 3) for _ in range(2)]
-    ])
-    b = np.random.rand(A.shape[0])
-
-    x_toe = solve_directly(A, b)
-    x_dumb = np.linalg.solve(A.full_matrix(), b)
-
-    assert np.allclose(x_toe, x_dumb, rtol=1e-6)
-
-
-def test_solve_block_circulant():
-    A = BlockCirculantMatrix([
-        [(lambda: np.random.rand(3, 3))() for _ in range(6)]
-    ])
-    b = np.random.rand(A.shape[0])
-
-    x_circ = solve_directly(A, b)
-    x_dumb = np.linalg.solve(A.full_matrix(), b)
-
-    assert np.allclose(x_circ, x_dumb, rtol=1e-6)
-
-    x_gmres = solve_gmres(A, b)
-    x_dumb_gmres = solve_gmres(A.full_matrix(), b)
-
-    assert np.allclose(x_gmres, x_dumb_gmres, rtol=1e-6)
-
-
-def test_solve_nested_block_circulant():
-    A = BlockCirculantMatrix([
-        [random_block_matrix([1, 1], [1, 1]) for _ in range(6)]
-    ])
-    b = np.random.rand(A.shape[0])
-
-    x_circ = solve_directly(A, b)
-    x_dumb = np.linalg.solve(A.full_matrix(), b)
-
-    assert np.allclose(x_circ, x_dumb, rtol=1e-6)
-
-    x_gmres = solve_gmres(A, b)
-    x_dumb_gmres = solve_gmres(A.full_matrix(), b)
-
-    assert np.allclose(x_gmres, x_dumb_gmres, rtol=1e-6)
-
-
-def test_solve_block_toeplitz():
-    A = BlockToeplitzMatrix([[(lambda: np.random.rand(1, 1))() for _ in range(7)]])
-    b = np.random.rand(A.shape[0])
-
-    assert np.allclose(BlockMatrix.matvec(A, b), A.full_matrix() @ b)
-    assert np.allclose(A @ b, A.full_matrix() @ b)
-
-    x_gmres = solve_gmres(A, b)
-    x_dumb_gmres = solve_gmres(A.full_matrix(), b)
-
-    assert np.allclose(x_gmres, x_dumb_gmres, rtol=1e-6)
 
 
 def test_low_rank_blocks():


### PR DESCRIPTION
When solving several BEM problems with the same matrix (that is several radiation problems identical but for the radiating dof, or several diffraction problems identical but for the wave direction), the current default is to solve each linear problem interdependently with a direct solver. This is very wasteful since the linear solver is computing the LU decomposition of the matrix several time.

This PR implement a new linear solver such that the LU decomposition of the last solved problem is kept in memory. Hence it can be reused directly for other problems involving the same matrix.

The speedup is very dependent of the use case (size of the mesh, how many radiating dofs, finite depth or infinite depth, parallelization, etc.). Reductions of the computation time up to 40% have been observed (e.g. `examples/radiation_cylinder.py` without symmetry).