### PR TITLE
Add placeholder to define rigid body when initializing the FloatingBody.

### DIFF
--- a/capytaine/__init__.py
+++ b/capytaine/__init__.py
@@ -13,6 +13,8 @@ from capytaine.meshes.collections import CollectionOfMeshes
 from capytaine.meshes.symmetric import ReflectionSymmetricMesh, TranslationalSymmetricMesh, AxialSymmetricMesh
 
 from capytaine.bodies.bodies import FloatingBody
+from capytaine.bodies.dofs import rigid_body_dofs
+
 from capytaine.bodies.predefined.spheres import Sphere
 from capytaine.bodies.predefined.cylinders import VerticalCylinder, HorizontalCylinder, Disk
 from capytaine.bodies.predefined.rectangles import Rectangle, RectangularParallelepiped, OpenRectangularParallelepiped

--- a/capytaine/bodies/bodies.py
+++ b/capytaine/bodies/bodies.py
@@ -61,8 +61,10 @@ class FloatingBody(Abstract3DObject):
             assert isinstance(mesh, Mesh) or isinstance(mesh, CollectionOfMeshes)
             self.mesh = mesh
 
-        if name is None:
-            self.name = mesh.name
+        if name is None and mesh is None:
+            self.name = "dummy_body"
+        elif name is None:
+            self.name = self.mesh.name
         else:
             self.name = name
 

--- a/capytaine/bodies/bodies.py
+++ b/capytaine/bodies/bodies.py
@@ -15,6 +15,7 @@ from capytaine.meshes.geometry import Abstract3DObject, Plane, inplace_transform
 from capytaine.meshes.meshes import Mesh
 from capytaine.meshes.symmetric import build_regular_array_of_meshes
 from capytaine.meshes.collections import CollectionOfMeshes
+from capytaine.bodies.dofs import RigidBodyDofsPlaceholder
 
 LOG = logging.getLogger(__name__)
 
@@ -55,21 +56,30 @@ class FloatingBody(Abstract3DObject):
 
     def __init__(self, mesh=None, dofs=None, mass=None, center_of_mass=None, name=None):
         if mesh is None:
-            mesh = Mesh(name="dummy_mesh")
-
-        if dofs is None:
-            dofs = {}
+            self.mesh = Mesh(name="dummy_mesh")
+        else:
+            assert isinstance(mesh, Mesh) or isinstance(mesh, CollectionOfMeshes)
+            self.mesh = mesh
 
         if name is None:
-            name = mesh.name
+            self.name = mesh.name
+        else:
+            self.name = name
 
-        assert isinstance(mesh, Mesh) or isinstance(mesh, CollectionOfMeshes)
-        self.mesh = mesh
-        self.full_body = None
-        self.dofs = dofs
         self.mass = mass
         self.center_of_mass = center_of_mass
-        self.name = name
+
+        if dofs is None:
+            self.dofs = {}
+        elif isinstance(dofs, RigidBodyDofsPlaceholder):
+            if dofs.rotation_center is not None:
+                self.rotation_center = np.asarray(dofs.rotation_center)
+            self.dofs = {}
+            self.add_all_rigid_body_dofs()
+        else:
+            self.dofs = dofs
+
+        self.full_body = None
 
         if self.mesh.nb_vertices == 0 or self.mesh.nb_faces == 0:
             LOG.warning(f"New floating body (with empty mesh!): {self.name}.")

--- a/capytaine/bodies/dofs.py
+++ b/capytaine/bodies/dofs.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2017-2022 Matthieu Ancellin
+# See LICENSE file at <https://github.com/capytaine/capytaine>
+
+
+class RigidBodyDofsPlaceholder:
+    """Pass an instance of this class to the FloatingBody initializer to initialize the 6 ridig body dofs."""
+
+    def __init__(self, rotation_center=None):
+        self.rotation_center = rotation_center
+
+
+def rigid_body_dofs(rotation_center=None):
+    return RigidBodyDofsPlaceholder(rotation_center=rotation_center)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -41,6 +41,8 @@ Minor changes
 
 * Add :meth:`~capytaine.bodies.bodies.FloatingBody.immersed_part` method to clip the body without modifying it in place (:pull:`244`).
 
+* Add :func:`~capytaine.rigid_body_dofs` method returning a placeholder that can be given at the creation of :class:`~capytaine.bodies.bodies.FloatingBody` to initialize the six rigid body dofs (:pull:`245`).
+
 * Custom classes from the :code:`capytaine.matrices` module storign block matrices or data-sparse matrices
   can be transformed into full Numpy arrays with :code:`np.array(...)` (:pull:`99`)
 

--- a/pytest/test_bodies.py
+++ b/pytest/test_bodies.py
@@ -45,6 +45,33 @@ def test_dof_name_inference():
     body.add_all_rigid_body_dofs()
 
 
+def test_rigid_body_dofs():
+    import capytaine as cpt
+    mesh = cpt.Sphere().mesh
+    body = cpt.FloatingBody(mesh=mesh, dofs=cpt.rigid_body_dofs(rotation_center=(10.0, 0.0, 0.0)))
+    assert "Heave" in body.dofs
+    assert np.all(body.dofs["Pitch"][:, 2] > 9.0)
+
+def test_rigid_body_dofs_no_rotation_center_but_a_center_of_mass():
+    import capytaine as cpt
+    mesh = cpt.Sphere().mesh
+    body = cpt.FloatingBody(mesh=mesh, dofs=cpt.rigid_body_dofs(), center_of_mass=(-10.0, 0.0, 0.0))
+    assert np.all(body.dofs["Pitch"][:, 2] < -9.0)
+
+def test_rigid_body_dofs_both_a_rotation_center_and_a_center_of_mass():
+    import capytaine as cpt
+    mesh = cpt.Sphere().mesh
+    body = cpt.FloatingBody(mesh=mesh, dofs=cpt.rigid_body_dofs(rotation_center=(10.0, 0.0, 0.0)),
+                            center_of_mass=(-10.0, 0.0, 0.0))
+    assert np.all(body.dofs["Pitch"][:, 2] > 9.0)
+
+def test_rigid_body_dofs_neither_a_rotation_center_nor_a_center_of_mass():
+    import capytaine as cpt
+    mesh = cpt.Sphere().mesh
+    body = cpt.FloatingBody(mesh=mesh, dofs=cpt.rigid_body_dofs())
+    assert np.allclose(body._infer_rotation_center(), (0.0, 0.0, 0.0))
+
+
 def test_bodies():
     body = Sphere(name="sphere", axial_symmetry=False)
     assert str(body) == "sphere"


### PR DESCRIPTION
This PR is part of #214

It adds an objects that can be passed to the `FloatingBody` initializer, such that the six rigid body dofs are defined for this body.

```
cpt.FloatingBody(mesh=..., dofs=cpt.rigid_body_dofs(), center_of_mass=...)
```

For now, the dofs cannot really be defined until the mesh is known. That is why `rigid_body_dofs` returns only a placeholder and the actual dofs are computed in `FloatingBody.__init__` where the mesh is known.

Once #215 is finalized, the placeholder returned by `rigid_body_dofs` might change and the implementation of this feature might evolve.
