### PR TITLE
Update tutorial

### DIFF
--- a/docs/user_manual/tutorial.rst
+++ b/docs/user_manual/tutorial.rst
@@ -73,10 +73,9 @@ Main concepts
 Step-by-step example
 ====================
 
-Launch an interactive Python console such as :code:`ipython`.
-All the main features of Capytaine can be loaded with::
+Launch an interactive Python console such as :code:`ipython` and import the Capytaine package::
 
-    from capytaine import *
+    import capytaine as cpt
 
 Note that Capytaine uses the logging module from Python. Then, you can optionally get some feedback from the code
 by initializing the logging module with the following commands::
@@ -87,7 +86,7 @@ by initializing the logging module with the following commands::
 Replace :code:`INFO` by :code:`DEBUG` to get more information on everything that is happening
 inside the solver. On the other hand, if you set the level to :code:`WARNING`, only important
 warnings will be printed out by the solver (this is the default behavior when the logging module
-has not been set up). 
+has not been set up).
 
 Load a mesh
 -----------
@@ -95,7 +94,7 @@ Load a mesh
 For this tutorial we will use one of the mesh generators included into Capytaine for simple
 geometric shapes::
 
-    sphere = Sphere(radius=1.0, center=(0, 0, -2), name="my buoy")
+    sphere = cpt.mesh_sphere(radius=1.0, center=(0, 0, -2), name="my sphere")
 
 Users can also import mesh from various file formats as shown in the :doc:`mesh`
 section of the documentation. The mesh is stored as a
@@ -103,85 +102,119 @@ section of the documentation. The mesh is stored as a
 coordinates of some of the vertices, faces centers or faces normal vectors using
 the following syntax::
 
-    sphere.mesh.vertices[:10]  # First ten vertices.
-    sphere.mesh.faces_centers[5]  # Center of the sixth face (Python arrays start at 0).
-    sphere.mesh.faces_normals[5]  # Normal vector of the sixth face.
+    sphere.vertices[:10]  # First ten vertices.
+    sphere.faces_centers[5]  # Center of the sixth face (Python arrays start at 0).
+    sphere.faces_normals[5]  # Normal vector of the sixth face.
 
 If `vtk` has been installed, the mesh can be displayed in 3D using::
 
     sphere.show()
 
-Defining dofs
--------------
+Defining a floating body
+------------------------
 
-Before solving a diffraction or radiation problem, we need to define the degrees of freedom (dofs) of our
-body. It can be done in several ways:
+Before solving a diffraction or radiation problem, we need to define the degrees of freedom (dofs) of our body.
+In Capytaine, this is done by creating a :code:`FloatingBody` object::
 
-* The manual way: define a list a vectors where each vector is the displacement of the
-  body at the center of a face. The example below is the simplest example of a rigid body motion in
-  the :math:`x` direction::
+    body = cpt.FloatingBody(mesh=sphere,
+                            dofs=cpt.rigid_body_dofs(rotation_center=(0, 0, -2)),
+                            center_of_mass=(0, 0, -2))
 
-    sphere.dofs['Surge'] = [(1, 0, 0) for face in sphere.mesh.faces]
+The new body defined here will have the six degrees of freedom of a rigid body.
+The :code:`rotation_center` is used for the definition of the rotation dofs.
+The :code:`center_of_mass` is used for some hydrostatics properties but not required for the diffraction-radiation problems.
 
-* Helpers functions are available to define rigid body translations and rotations. For instance for
-  the motion in the :math:`z` direction, we can use :meth:`FloatingBody.add_translation_dof <capytaine.bodies.bodies.FloatingBody.add_translation_dof>`.
-  It can recognize some dof names such as "Surge", "Sway" and "Heave"::
+The degrees of freedoms are stored in the :code:`dofs` dictionary. To access the name of the dofs of a body, you can use for instance::
 
-    sphere.add_translation_dof(name="Heave")
+    print(body.dofs.keys())
+    # dict_keys(['Surge', 'Sway', 'Heave', 'Roll', 'Pitch', 'Yaw'])
 
-  See the documentation of :meth:`FloatingBody.add_rotation_dof <capytaine.bodies.bodies.FloatingBody.add_rotation_dof>` and :meth:`FloatingBody.add_all_rigid_body_dofs <capytaine.bodies.bodies.FloatingBody.add_all_rigid_body_dofs>`.
+Dofs can also be defined manually, for instance to model a flexible body. For this purpose, one has to define a list a vectors where each vector is the displacement of the body at the center of a face::
 
-The degrees of freedoms are stored in the :code:`dofs` dictionary. To access the name of the dofs of a
-body, you can use for instance::
+    import numpy as np
+    body.dofs["x-shear"] = [(np.cos(np.pi*z/2), 0, 0) for x, y, z in sphere.faces_centers]
 
-    print(sphere.dofs.keys())
-    # dict_keys(['Surge', 'Heave'])
+    print(body.dofs.keys())
+    # dict_keys(['Surge', 'Sway', 'Heave', 'Roll', 'Pitch', 'Yaw', 'x-shear'])
 
 Hydrostatics
 ------------
 
-Capytaine can directly perform some hydrostatic computation for a given mesh. You can get parameters such as volume, wet surface area, waterplane area, center of buoyancy, metacentric radius and height, hydrostatic stiffness and interia mass for any given :code:`FloatingBody`.
-
-Let us give the code some more information about the body::
-
-    sphere.center_of_mass = (0, 0, -2)
-    sphere.rotation_center = (0, 0, -2)
-
-The "rotation center" is the point used to define the rotation dofs.
-(Due to a current limitation of the hydrostatics methods, the definition of the rotation center is required as soon as there is a rigid body dof — here surge and heave —, even if it is not a rotation dof.)
+Capytaine can directly perform some hydrostatic computations. You can get parameters such as volume, wet surface area, waterplane area, center of buoyancy, metacentric radius and height, hydrostatic stiffness and interia mass for any given :code:`FloatingBody`.
 
 Each hydrostatic parameter can be computed by a dedicated method::
 
-    print(sphere.volume)
+    print(body.volume)
     # 3.82267415555807
 
-    print(sphere.center_of_buoyancy)
-    # [-3.58784373e-17 -2.59455034e-17 -2.00000000e+00]
+    print(body.center_of_buoyancy)
+    # [-4.67908710e-17  5.87788602e-18 -2.00000000e+00]
 
-    print(sphere.compute_hydrostatic_stiffness())
-    # <xarray.DataArray 'hydrostatic_stiffness' (influenced_dof: 2, radiating_dof: 2)>
-    # array([[0.00000000e+00, 0.00000000e+00],
-    #        [0.00000000e+00, 2.38246922e-13]])
+    print(body.compute_hydrostatic_stiffness())
+    # <xarray.DataArray 'hydrostatic_stiffness' (influenced_dof: 7, radiating_dof: 7)>
+    # array([[ 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
+    #          0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
+    #          0.00000000e+00],
+    #        [ 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
+    #          0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
+    #          0.00000000e+00],
+    #        [ 0.00000000e+00,  0.00000000e+00, -7.14740767e-13,
+    #          1.23165150e-12,  7.23249585e-13,  0.00000000e+00,
+    #         -2.22292887e-13],
+    #        [ 0.00000000e+00,  0.00000000e+00,  1.23165150e-12,
+    #         -1.67095099e-11, -6.43479410e-14,  1.75467795e-12,
+    #          1.91235699e-12],
+    #        [ 0.00000000e+00,  0.00000000e+00,  7.23249585e-13,
+    #         -6.43479410e-14, -1.64759163e-11, -2.20423274e-13,
+    #         -2.92821569e+04],
+    #        [ 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
+    #          0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
+    #          0.00000000e+00],
+    #        [ 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
+    #          0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
+    #          0.00000000e+00]])
     # Coordinates:
-    #   * influenced_dof  (influenced_dof) <U5 'Surge' 'Heave'
-    #   * radiating_dof   (radiating_dof) <U5 'Surge' 'Heave'
+    #   * influenced_dof  (influenced_dof) <U7 'Surge' 'Sway' ... 'Yaw' 'x-shear'
+    #   * radiating_dof   (radiating_dof) <U7 'Surge' 'Sway' ... 'Yaw' 'x-shear'
 
-    print(sphere.compute_rigid_body_inertia())
-    # <xarray.DataArray 'inertia_matrix' (influenced_dof: 2, radiating_dof: 2)>
-    # array([[3822.67415556,    0.        ],
-    #        [   0.        , 3822.67415556]])
+    print(body.compute_rigid_body_inertia())
+    # Non-rigid dofs: {'x-shear'} are detected and respective inertia coefficients are assigned as N
+    # aN.
+    # <xarray.DataArray 'inertia_matrix' (influenced_dof: 7, radiating_dof: 7)>
+    # array([[ 3.82267416e+03,  0.00000000e+00,  0.00000000e+00,
+    #          0.00000000e+00,  0.00000000e+00, -0.00000000e+00,
+    #                     nan],
+    #        [ 0.00000000e+00,  3.82267416e+03,  0.00000000e+00,
+    #         -0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
+    #                     nan],
+    #        [ 0.00000000e+00,  0.00000000e+00,  3.82267416e+03,
+    #          0.00000000e+00, -0.00000000e+00,  0.00000000e+00,
+    #                     nan],
+    #        [ 0.00000000e+00, -0.00000000e+00,  0.00000000e+00,
+    #          1.41810840e+03,  1.19262239e-14,  9.97465999e-15,
+    #                     nan],
+    #        [ 0.00000000e+00,  0.00000000e+00, -0.00000000e+00,
+    #          1.19262239e-14,  1.41810840e+03,  5.15605896e-14,
+    #                     nan],
+    #        [-0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
+    #          9.97465999e-15,  5.15605896e-14,  1.35727139e+03,
+    #                     nan],
+    #        [            nan,             nan,             nan,
+    #                     nan,             nan,             nan,
+    #                     nan]])
     # Coordinates:
-    #   * influenced_dof  (influenced_dof) <U5 'Surge' 'Heave'
-    #   * radiating_dof   (radiating_dof) <U5 'Surge' 'Heave'
+    #   * influenced_dof  (influenced_dof) <U7 'Surge' 'Sway' ... 'Yaw' 'x-shear'
+    #   * radiating_dof   (radiating_dof) <U7 'Surge' 'Sway' ... 'Yaw' 'x-shear'
 
-The matrices here are :math:`2 \times 2` matrices as we have defined only two dofs for our sphere.
+The matrices here are :math:`7 \times 7` matrices as we have defined seven dofs for our sphere.
+The matrices are stored as :code:`DataArray` from the `xarray <https://xarray.dev/>`_ package (see below for an example of usage).
 
 You can also use :code:`compute_hydrostatics` method which computes all hydrostatic parameters and returns a :code:`dict` of parameters and values::
 
-    hydrostatics = sphere.compute_hydrostatics()
+    hydrostatics = body.compute_hydrostatics()
 
 .. note::
-   Before computing hydrostatic parameters, you might want to crop your mesh using `immersed_body = body.immersed_part()`.
+   Before computing some hydrostatic parameters, you might want to crop your mesh using `immersed_body = body.immersed_part()`.
    It is not required here since the sphere is fully immersed.
    Cropping is included in the :code:`compute_hydrostatics()` function.
 
@@ -192,7 +225,7 @@ Defining linear potential flow problems.
 Let us define a radiation problem for the heave of our sphere::
 
     from numpy import infty
-    problem = RadiationProblem(body=sphere, radiating_dof="Heave", omega=1.0, sea_bottom=-infty, g=9.81, rho=1000)
+    problem = cpt.RadiationProblem(body=body, radiating_dof="Heave", omega=1.0, sea_bottom=-infty, g=9.81, rho=1000)
 
 The argument :code:`radiating_dof` must be the name of one of the dofs of the floating body given as the
 :code:`body` argument. The wave angular frequency has been set arbitrarily as :math:`\omega = 1 \, \text{rad/s}`.
@@ -200,7 +233,7 @@ The water depth is infinite, the gravity acceleration is :math:`g = 9.81 \, \tex
 been chosen as :math:`\rho = 1000 \, \text{kg/m}^3`. These last parameters are actually optional.
 Since we are using their default value, we could have defined the radiation problem as::
 
-    problem = RadiationProblem(body=sphere, radiating_dof="Heave", omega=1.0)
+    problem = cpt.RadiationProblem(body=body, radiating_dof="Heave", omega=1.0)
 
 Some more parameters are automatically computed, such as::
 
@@ -214,7 +247,7 @@ Solve the problem
 
 Let us initialize the BEM solver::
 
-    solver = BEMSolver()
+    solver = cpt.BEMSolver()
 
 Solver settings could have been given at this point, but in this tutorial, we will use the default settings.
 Let us now solve the problem we defined earlier::
@@ -237,7 +270,7 @@ Of course, it also stores some output data. Since we solved a radiation problem,
 the added mass and radiation damping::
 
     print(result.added_masses)
-    # {'Surge': 9.154531598110083e-06, 'Heave': 2207.8423200090374}
+    # {'Surge': -2.2737367544323206e-13, 'Sway': 2.8421709430404007e-13, 'Heave': 2207.842170942399, 'Roll': -5.3290705182007514e-14, 'Pitch': 1.3289369604763124e-13, 'Yaw': -4.0933040491086855e -15, 'x-shear': 1.3677947663381929e-13}
 
 The :code:`added_masses` dictionary stores the resulting force on each of the "influenced dofs" of the body.
 In this example, the radiating dof is heave and the reaction force in the
@@ -248,14 +281,14 @@ respect to the one in the :math:`z` direction
 ::
 
     print(result.radiation_dampings)
-    # {'Surge': -5.792518686098536e-07, 'Heave': 13.62318484050783}
+    # {'Surge': -9.103828801926284e-15, 'Sway': 0.0, 'Heave': 13.623038091677039, 'Roll': -1.7486012 637846216e-15, 'Pitch': 3.4937330806172895e-15, 'Yaw': 9.7897500502683e-17, 'x-shear': 7.27196 0811294775e-15}
 
 Gather results in arrays
 ------------------------
 
 Let us compute the added mass and radiation damping for surge::
 
-    other_problem = RadiationProblem(body=sphere, radiating_dof="Surge", omega=1.0)
+    other_problem = cpt.RadiationProblem(body=body, radiating_dof="Surge", omega=1.0)
     other_result = solver.solve(other_problem)
 
 Note that this second resolution should be faster than the first one. The solver has stored some
@@ -263,7 +296,7 @@ intermediate data for this body and will reuse them to solve this other problem.
 
 The results can be gathered together as follow::
 
-    dataset = assemble_dataset([result, other_result])
+    dataset = cpt.assemble_dataset([result, other_result])
 
 The new object is a NetCDF-like dataset from the xarray package. It is storing the added mass and
 radiation damping from the result objects in an organized way. In our example, it is basically two

--- a/docs/user_manual/tutorial.rst
+++ b/docs/user_manual/tutorial.rst
@@ -208,6 +208,7 @@ Each hydrostatic parameter can be computed by a dedicated method::
 
 The matrices here are :math:`7 \times 7` matrices as we have defined seven dofs for our sphere.
 The matrices are stored as :code:`DataArray` from the `xarray <https://xarray.dev/>`_ package (see below for an example of usage).
+Note that the inertia matrix can only be computed for rigid bodies (assuming constant density). The matrix was filled with :code:`NaN` for the generalized dof :code:`x-shear`.
 
 You can also use :code:`compute_hydrostatics` method which computes all hydrostatic parameters and returns a :code:`dict` of parameters and values::
 


### PR DESCRIPTION
- Use explicit namespace: `import capytaine as cpt` instead of `from capytaine import *`
- Use new recommended methods for FloatingBody definition (#214 et al.)