### PR TITLE
add long_name to dataset attrs

### DIFF
--- a/capytaine/io/xarray.py
+++ b/capytaine/io/xarray.py
@@ -329,6 +329,8 @@ def assemble_dataset(results,
             optional_dims=optional_dims)
         radiation_cases.added_mass.attrs['long_name'] = 'Added mass'
         radiation_cases.radiation_damping.attrs['long_name'] = 'Radiation damping'
+        radiation_cases.radiating_dof.attrs['long_name'] = 'Radiating DOF'
+        radiation_cases.influenced_dof.attrs['long_name'] = 'Influenced DOF'
         dataset = xr.merge([dataset, radiation_cases])
 
     # DIFFRACTION RESULTS
@@ -346,6 +348,9 @@ def assemble_dataset(results,
             optional_dims=optional_dims)
         diffraction_cases.diffraction_force.attrs['long_name'] = 'Diffraction force'
         diffraction_cases.Froude_Krylov_force.attrs['long_name'] = 'Froude Krylov force'
+        diffraction_cases.influenced_dof.attrs['long_name'] = 'Influenced DOF'
+        diffraction_cases.wave_direction.attrs['long_name'] = 'Wave direction'
+        diffraction_cases.wave_direction.attrs['units'] = 'rad'
         dataset = xr.merge([dataset, diffraction_cases])
 
     # WAVENUMBER

--- a/capytaine/io/xarray.py
+++ b/capytaine/io/xarray.py
@@ -327,6 +327,8 @@ def assemble_dataset(results,
             variables=['added_mass', 'radiation_damping'],
             dimensions=['omega', 'radiating_dof', 'influenced_dof'],
             optional_dims=optional_dims)
+        radiation_cases.added_mass.attrs['long_name'] = 'Added mass'
+        radiation_cases.radiation_damping.attrs['long_name'] = 'Radiation damping'
         dataset = xr.merge([dataset, radiation_cases])
 
     # DIFFRACTION RESULTS
@@ -342,6 +344,8 @@ def assemble_dataset(results,
             variables=['diffraction_force', 'Froude_Krylov_force'],
             dimensions=['omega', 'wave_direction', 'influenced_dof'],
             optional_dims=optional_dims)
+        diffraction_cases.diffraction_force.attrs['long_name'] = 'Diffraction force'
+        diffraction_cases.Froude_Krylov_force.attrs['long_name'] = 'Froude Krylov force'
         dataset = xr.merge([dataset, diffraction_cases])
 
     # WAVENUMBER
@@ -355,6 +359,7 @@ def assemble_dataset(results,
             dataset.coords['wavenumber'] = wavenumber_ds['wavenumber']
         else:
             dataset.coords['wavenumber'] = wavenumber_data_array(results)
+        dataset.wavenumber.attrs['long_name'] = 'Wave number'
 
     if wavelength:
         if bemio_import:
@@ -366,6 +371,7 @@ def assemble_dataset(results,
             dataset.coords['wavelength'] = wavelength_ds['wavelength']
         else:
             dataset.coords['wavelength'] = 2*np.pi/wavenumber_data_array(results)
+        dataset.wavelength.attrs['long_name'] = 'Wave length'
 
     if mesh:
         if bemio_import:
@@ -399,6 +405,8 @@ def assemble_dataset(results,
 
     dataset.attrs.update(attrs)
     dataset.attrs['capytaine_version'] = __version__
+    dataset.omega.attrs['long_name'] = 'Radial frequency'
+    dataset.omega.attrs['units'] = 'rad/s'
     return dataset
 
 


### PR DESCRIPTION
When plotting directly from the `xr.Dataset` produced by `capytaine`, you can get nicer axis labelling by populating the `attrs['long_name']` entry. Units can also be added, but given the generalized modes I think it is probably best to leave this out.