### PR TITLE
Remove legacy Nemoh class.

### DIFF
--- a/capytaine/__init__.py
+++ b/capytaine/__init__.py
@@ -23,7 +23,7 @@ from capytaine.bodies.predefined.cylinders import VerticalCylinder, HorizontalCy
 from capytaine.bodies.predefined.rectangles import Rectangle, RectangularParallelepiped, OpenRectangularParallelepiped
 
 from capytaine.bem.problems_and_results import RadiationProblem, DiffractionProblem
-from capytaine.bem.solver import Nemoh, BEMSolver
+from capytaine.bem.solver import BEMSolver
 from capytaine.bem.engines import BasicMatrixEngine, HierarchicalToeplitzMatrixEngine
 from capytaine.green_functions.delhommeau import Delhommeau, XieDelhommeau
 

--- a/capytaine/bem/solver.py
+++ b/capytaine/bem/solver.py
@@ -252,36 +252,3 @@ class BEMSolver:
             result.fs_elevation[free_surface] = fs_elevation
         return fs_elevation
 
-
-# LEGACY INTERFACE
-
-def _arguments(f):
-    """Returns the name of the arguments of the function f"""
-    return f.__code__.co_varnames[:f.__code__.co_argcount]
-
-class Nemoh(BEMSolver):
-    """Solver for the BEM problem based on Nemoh's Green function. Legacy API.
-    Parameters are dispatched to the Delhommeau class and to the engine
-    (BasicMatrixEngine or HierarchicalToeplitzMatrixEngine).
-    """
-
-    def __init__(self, **params):
-        green_function = Delhommeau(
-           **{key: params[key] for key in params if key in _arguments(Delhommeau.__init__)}
-	)
-        if 'hierarchical_matrices' in params and params['hierarchical_matrices']:
-            engine = HierarchicalToeplitzMatrixEngine(
-               **{key: params[key] for key in params if key in _arguments(HierarchicalToeplitzMatrixEngine.__init__)}
-            )
-        else:
-            engine = BasicMatrixEngine(
-               **{key: params[key] for key in params if key in _arguments(BasicMatrixEngine.__init__)}
-            )
-
-        super().__init__(green_function=green_function, engine=engine)
-
-    def build_matrices(self, *args, **kwargs):
-        """Legacy API."""
-        args = args + (self.green_function,)
-        return self.engine.build_matrices(*args, **kwargs)
-

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,8 @@ Minor changes
 
 * Add functions :func:`~capytaine.io.mesh_loaders.load_PNL` and :func:`~capytaine.io.mesh_writers.write_PNL` to load and write meshes in HAMS ``.pnl`` format (:pull:`289`).
 
+* Remove ``cpt.Nemoh()`` class that was replaced by :class:`~capytaine.bem.solver.BEMSolver` in version 1.1 (:pull:`291`)
+
 -------------------------------
 New in version 1.5 (2022-12-13)
 -------------------------------

--- a/docs/user_manual/resolution.rst
+++ b/docs/user_manual/resolution.rst
@@ -84,18 +84,6 @@ Two of them are available in the present version:
       precision of the low-rank matrices.
 
 
-Legacy interface
-----------------
-
-The class :class:`~capytaine.bem.solver.Nemoh` was the main solver class in
-version 1.0 of Capytaine.
-It is still available in the current version for backward compatibility.
-It is now a subclass of :class:`~capytaine.bem.solver.BEMSolver` that always uses
-:class:`~capytaine.green_functions.delhommeau.Delhommeau`'s Green function and
-accept the same arguments as in version 1.0.
-
-The use of :class:`~capytaine.bem.solver.BEMSolver` is recommended.
-
 Solving the problem
 -------------------
 

--- a/pytest/test_bem_hierarchical_toeplitz_matrices.py
+++ b/pytest/test_bem_hierarchical_toeplitz_matrices.py
@@ -16,15 +16,14 @@ from capytaine.bodies.predefined.spheres import Sphere
 from capytaine.bodies.predefined.cylinders import HorizontalCylinder, VerticalCylinder
 
 from capytaine.bem.problems_and_results import RadiationProblem
-from capytaine.bem.solver import Nemoh
 from capytaine.io.xarray import assemble_dataset
 
 from capytaine.meshes.geometry import xOz_Plane, yOz_Plane
 
 from capytaine.matrices.low_rank import LowRankMatrix
 
-solver_with_sym = Nemoh(hierarchical_matrices=True, ACA_distance=8, matrix_cache_size=0)
-solver_without_sym = Nemoh(hierarchical_matrices=False, ACA_distance=8, matrix_cache_size=0)
+solver_with_sym = cpt.BEMSolver(engine=cpt.HierarchicalToeplitzMatrixEngine(ACA_distance=8, matrix_cache_size=0))
+solver_without_sym = cpt.BEMSolver(engine=cpt.BasicMatrixEngine(matrix_cache_size=0))
 # Use a single solver in the whole module to avoid reinitialisation of the solver (0.5 second).
 # Do not use a matrix cache in order not to risk influencing a test with another.
 
@@ -158,7 +157,7 @@ def test_low_rank_matrices():
     two_distant_buoys = FloatingBody.join_bodies(buoy, buoy.translated_x(20))
     two_distant_buoys.mesh._meshes[1].name = "other_buoy_mesh"
 
-    S, V = solver_with_sym.build_matrices(two_distant_buoys.mesh, two_distant_buoys.mesh, 0.0, -np.infty, 1.0)
+    S, V = solver_with_sym.engine.build_matrices(two_distant_buoys.mesh, two_distant_buoys.mesh, 0.0, -np.infty, 1.0, solver_with_sym.green_function)
     assert isinstance(S.all_blocks[0, 1], LowRankMatrix)
     assert isinstance(S.all_blocks[1, 0], LowRankMatrix)
     # S.plot_shape()
@@ -199,12 +198,8 @@ def test_array_of_spheres():
     #
     array = buoy.assemble_regular_array(distance=4.0, nb_bodies=(3, 1))
 
-    settings = dict(cache_rankine_matrices=False, matrix_cache_size=0)
-    nemoh_without_sym = Nemoh(hierarchical_matrices=False, **settings)
-    nemoh_with_sym = Nemoh(hierarchical_matrices=True, **settings)
-
-    fullS, fullV = nemoh_without_sym.build_matrices(array.mesh, array.mesh, 0.0, -np.infty, 1.0)
-    S, V = nemoh_with_sym.build_matrices(array.mesh, array.mesh, 0.0, -np.infty, 1.0)
+    fullS, fullV = solver_without_sym.engine.build_matrices(array.mesh, array.mesh, 0.0, -np.infty, 1.0, solver_without_sym.green_function)
+    S, V = solver_with_sym.engine.build_matrices(array.mesh, array.mesh, 0.0, -np.infty, 1.0, solver_with_sym.green_function)
 
     assert isinstance(S, cpt.matrices.block.BlockMatrix)
     assert np.allclose(S.full_matrix(), fullS)
@@ -212,8 +207,8 @@ def test_array_of_spheres():
 
     problem = RadiationProblem(body=array, omega=1.0, radiating_dof="2_0__Heave", sea_bottom=-np.infty)
 
-    result = nemoh_with_sym.solve(problem)
-    result2 = nemoh_without_sym.solve(problem)
+    result = solver_with_sym.solve(problem)
+    result2 = solver_without_sym.solve(problem)
 
     assert np.isclose(result.added_masses['2_0__Heave'], result2.added_masses['2_0__Heave'], atol=15.0)
     assert np.isclose(result.radiation_dampings['2_0__Heave'], result2.radiation_dampings['2_0__Heave'], atol=15.0)

--- a/pytest/test_bem_linear_combination_of_dofs.py
+++ b/pytest/test_bem_linear_combination_of_dofs.py
@@ -4,6 +4,7 @@
 import numpy as np
 import capytaine as cpt
 
+solver = cpt.BEMSolver()
 
 def test_sum_of_dofs():
     body1 = cpt.Sphere(radius=1.0, ntheta=3, nphi=12, center=(0, 0, -3), name="body1")
@@ -16,7 +17,6 @@ def test_sum_of_dofs():
     both.add_translation_dof(name="Heave")
 
     problems = [cpt.RadiationProblem(body=both, radiating_dof=dof, omega=1.0) for dof in both.dofs]
-    solver = cpt.Nemoh()
     results = solver.solve_all(problems)
     dataset = cpt.assemble_dataset(results)
 
@@ -38,7 +38,6 @@ def test_rotation_axis():
     assert np.allclose(body.dofs['other_rotation'], (body.dofs['Yaw'] - l*body.dofs['Sway']))
 
     problems = [cpt.RadiationProblem(body=body, radiating_dof=dof, omega=1.0) for dof in body.dofs]
-    solver = cpt.Nemoh()
     results = solver.solve_all(problems, keep_details=True)
     dataset = cpt.assemble_dataset(results)
 

--- a/pytest/test_bem_problems_and_results.py
+++ b/pytest/test_bem_problems_and_results.py
@@ -20,7 +20,6 @@ from capytaine.bodies.predefined.cylinders import HorizontalCylinder
 
 from capytaine.bem.problems_and_results import LinearPotentialFlowProblem, DiffractionProblem, RadiationProblem, \
     LinearPotentialFlowResult, DiffractionResult, RadiationResult
-from capytaine.bem.solver import Nemoh
 from capytaine.io.xarray import problems_from_dataset, assemble_dataset
 
 from capytaine.io.legacy import import_cal_file

--- a/pytest/test_bem_solver.py
+++ b/pytest/test_bem_solver.py
@@ -10,7 +10,7 @@ except ImportError:
     joblib = None
 
 from capytaine import __version__
-from capytaine.bem.solver import BEMSolver, Nemoh
+from capytaine.bem.solver import BEMSolver
 from capytaine.green_functions.delhommeau import Delhommeau, XieDelhommeau
 from capytaine.bem.engines import BasicMatrixEngine
 from capytaine.bem.problems_and_results import RadiationProblem

--- a/pytest/test_consistency_with_Nemoh_2.py
+++ b/pytest/test_consistency_with_Nemoh_2.py
@@ -3,18 +3,18 @@
 """Quantitatively compare the results of Capytaine with the results from Nemoh 2."""
 
 import numpy as np
+import capytaine as cpt
 
 from capytaine.bodies.predefined.spheres import Sphere
 from capytaine.bodies.predefined.cylinders import HorizontalCylinder
 from capytaine.post_pro.free_surfaces import FreeSurface
 
 from capytaine.bem.problems_and_results import DiffractionProblem, RadiationProblem
-from capytaine.bem.solver import Nemoh
 from capytaine.green_functions.delhommeau import Delhommeau
 from capytaine.io.xarray import assemble_dataset
 from capytaine.post_pro.kochin import compute_kochin
 
-solver = Nemoh(linear_solver='gmres', hierarchical_matrices=False, matrix_cache_size=0)
+solver = cpt.BEMSolver(engine=cpt.BasicMatrixEngine(matrix_cache_size=0))
 
 
 def test_immersed_sphere():


### PR DESCRIPTION
Until v1.1, the solver was the `cpt.Nemoh()` class. In v1.1, the better-named class `cpt.BEMSolver` was introduced, while `Nemoh()` was kept for backward compatibility. This PR removes `Nemoh()` and all mentions of it.