### PR TITLE
Fix video autoplay in Chrome on main doc page.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ Please, report bugs and suggest improvements as `Github issues <https://github.c
 .. raw:: html
 
     <div style="float: right;">
-    <video src="_static/front_page_animation.ogv" loop autoplay width="320" height="240">
+    <video src="_static/front_page_animation.ogv" loop autoplay muted width="320" height="240">
     </video>
     </div>
 


### PR DESCRIPTION
Chrome users have been missing the animation on the front page.