### PR TITLE
Remove full_body attribute in bodies.

### DIFF
--- a/capytaine/bodies/bodies.py
+++ b/capytaine/bodies/bodies.py
@@ -91,8 +91,6 @@ class FloatingBody(Abstract3DObject):
         else:
             self.dofs = dofs
 
-        self.full_body = None
-
         if self.mesh.nb_vertices == 0 or self.mesh.nb_faces == 0:
             LOG.warning(f"New floating body (with empty mesh!): {self.name}.")
         else:
@@ -945,10 +943,6 @@ respective inertia coefficients are assigned as NaN.")
 
     @inplace_transformation
     def clip(self, plane):
-        # Keep of copy of the full mesh
-        if self.full_body is None:
-            self.full_body = self.copy()
-
         # Clip mesh
         LOG.info(f"Clipping {self.name} with respect to {plane}")
         self.mesh.clip(plane)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,6 +37,8 @@ Minor changes
 
 * Add function :func:`~capytaine.bem.airy_waves.airy_waves_free_surface_elevation` to compute the free surface elevation at points (:pull:`293`).
 
+* Remove ``full_body`` attribute from :class:`~capytaine.bodies.bodies.FloatingBody` that used to keep a copy of the body before clipping in-place (:pull:`302`).
+
 -------------------------------
 New in version 1.5 (2022-12-13)
 -------------------------------


### PR DESCRIPTION
Clipping in-place a body used to leave a copy of the original object as attribute of the new clipped body under the name `full_body`.
However this feature is clunky, as other transformation of the body do not update the `full_body`.

Best practice should be not to use in-place clipping but to prefer the `clipped()` and `immersed_part()` methods. Then the full body is still available and no `full_body` attribute is required.