### PR TITLE
Distribute Capytaine with PyInstaller

### DIFF
--- a/run_pyinstaller.sh
+++ b/run_pyinstaller.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+# Run in a environment created with
+# conda create -n capy_install -c conda-forge capytaine pyinstaller
+
+CAPY_BINARIES_DIR="$CONDA_PREFIX/lib/python3.10/site-packages/capytaine/green_functions/libs/"
+
+BINARIES=""
+for f in $CAPY_BINARIES_DIR/*; do
+    BINARIES="--add-binary=$f:capytaine/green_functions/libs/ $BINARIES";
+done
+
+pyinstaller --clean --onefile --noconfirm $BINARIES examples/custom_dofs.py

--- a/run_pyinstaller.sh
+++ b/run_pyinstaller.sh
@@ -10,4 +10,4 @@ for f in $CAPY_BINARIES_DIR/*; do
     BINARIES="--add-binary=$f:capytaine/green_functions/libs/ $BINARIES";
 done
 
-pyinstaller --clean --onefile --noconfirm $BINARIES examples/custom_dofs.py
+pyinstaller --clean --onefile --noconfirm $BINARIES $CONDA_PREFIX/bin/capytaine


### PR DESCRIPTION
Trying to build an independent executable from the conda-forge package.

TODO:
- [X] Have an executable working
- [x] Distribute the Nemoh-like command-line interface
- [ ] Distribute an executable able to run a Python script invoking Capytaine...
- [ ] ... including plots and 3d visualisation.
- [ ] Windows version
- [ ] MacOS version
