### PR TITLE
Update required Python version in docs to 3.7

### DIFF
--- a/docs/developer_manual/installation.rst
+++ b/docs/developer_manual/installation.rst
@@ -11,7 +11,7 @@ It is recommended to use a `conda environment <https://conda.io/docs/user-guide/
     conda activate capy_dev
 
 By default, conda will install the latest version of Python.
-Capytaine requires Python 3.6 and is compatible with `all currently supported version of Python <https://devguide.python.org/versions/>`_.
+Capytaine requires Python 3.7 and is compatible with `all currently supported version of Python <https://devguide.python.org/versions/>`_.
 
 
 You'll also need a Fortran compiler:

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -12,7 +12,7 @@ Capytaine is based on
 .. _meshmagick: https://github.com/LHEEA/meshmagick
 .. _`Python scientific ecosystem`: https://scipy.org/
 
-For users, it can be seen as a Python 3.6 (or higher) interface to Nemoh.
+For users, it can be seen as a Python 3.7 (or higher) interface to Nemoh.
 Since most of the code has been rewritten, it can be used by developers as a
 more concise and better documented version of Nemoh.
 

--- a/docs/user_manual/installation.rst
+++ b/docs/user_manual/installation.rst
@@ -6,7 +6,7 @@ Capytaine is available on Windows, MacOS [#]_ and Linux.
 
 .. [#] For the latest informations on the arm64 architectures (Apple M1), see https://github.com/capytaine/capytaine/issues/190
 
-Capytaine requires Python 3.6 or higher.
+Capytaine requires Python 3.7 or higher.
 Thus it is compatible with `all currently supported version of Python <https://devguide.python.org/versions/>`_.
 
 With Conda


### PR DESCRIPTION
Since #79, Capytaine requires pandas 1.3 which itself requires Python 3.7.

So effectively, Capytaine is not compatible with Python 3.6.

It is not really an issue since 3.6 is a bit out-dated and e.g. conda-forge has not been building Capytaine package for that version of Python for a while.