### PR TITLE
Allow users to set `water_depth` instead of `sea_bottom`

### DIFF
--- a/capytaine/bem/airy_waves.py
+++ b/capytaine/bem/airy_waves.py
@@ -26,7 +26,7 @@ def airy_waves_potential(points, pb):
 
     x, y, z = points.T
     k = pb.wavenumber
-    h = pb.depth
+    h = pb.water_depth
     wbar = x * np.cos(pb.wave_direction) + y * np.sin(pb.wave_direction)
 
     if 0 <= k*h < 20:
@@ -60,7 +60,7 @@ def airy_waves_velocity(points, pb):
 
     x, y, z = points.T
     k = pb.wavenumber
-    h = pb.depth
+    h = pb.water_depth
 
     wbar = x * np.cos(pb.wave_direction) + y * np.sin(pb.wave_direction)
 

--- a/capytaine/bem/problems_and_results.py
+++ b/capytaine/bem/problems_and_results.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from scipy.optimize import newton
 
+from capytaine.tools.deprecation_handling import _get_water_depth
 from capytaine.meshes.collections import CollectionOfMeshes
 from capytaine.bem.airy_waves import airy_waves_velocity, froude_krylov_force
 
@@ -66,22 +67,12 @@ class LinearPotentialFlowProblem:
         self.rho = float(rho)
         self.g = float(g)
 
-        if water_depth is None and sea_bottom is None:
-            self.water_depth = _default_parameters['water_depth']
-        elif water_depth is not None and sea_bottom is None:
-            self.water_depth = float(water_depth)
-        elif water_depth is None and sea_bottom is not None:
-            LOG.warning("Deprecation warning: please prefer giving a `water_depth` rather than a `sea_bottom` to define problems.")
-            self.water_depth = -float(sea_bottom)
-        else:
-            raise ValueError("Cannot give both a `water_depth` and a `sea_bottom` to define problems.")
-
         self.boundary_condition = boundary_condition
 
+        self.water_depth = _get_water_depth(free_surface, water_depth, sea_bottom, default_water_depth=_default_parameters["water_depth"])
         self.omega, self.provided_freq_type = self._get_angular_frequency(omega, period, wavenumber, wavelength)
 
         self._check_data()
-
 
     def _get_angular_frequency(self, omega, period, wavenumber, wavelength):
         frequency_data = dict(omega=omega, period=period, wavenumber=wavenumber, wavelength=wavelength)

--- a/capytaine/bem/problems_and_results.py
+++ b/capytaine/bem/problems_and_results.py
@@ -173,7 +173,7 @@ class LinearPotentialFlowProblem:
         """Do not display default values in str(problem)."""
         parameters = [f"body={self.body_name}",
                       f"omega={self.omega:.3f}",
-                      f"depth={self.water_depth}"]
+                      f"water_depth={self.water_depth}"]
         try:
             parameters.extend(self._str_other_attributes())
         except AttributeError:

--- a/capytaine/bem/solver.py
+++ b/capytaine/bem/solver.py
@@ -91,7 +91,7 @@ class BEMSolver:
 
         S, K = self.engine.build_matrices(
             problem.body.mesh, problem.body.mesh,
-            problem.free_surface, problem.sea_bottom, problem.wavenumber,
+            problem.free_surface, -problem.water_depth, problem.wavenumber,
             self.green_function
         )
         sources = self.engine.linear_solver(K, problem.boundary_condition)
@@ -199,7 +199,7 @@ class BEMSolver:
             They probably have not been stored by the solver because the option keep_details=True have not been set.
             Please re-run the resolution with this option.""")
 
-        S, _ = self.green_function.evaluate(points, result.body.mesh, result.free_surface, result.sea_bottom, result.wavenumber)
+        S, _ = self.green_function.evaluate(points, result.body.mesh, result.free_surface, -result.water_depth, result.wavenumber)
         potential = S @ result.sources  # Sum the contributions of all panels in the mesh
         return potential.reshape(output_shape)
 
@@ -232,7 +232,7 @@ class BEMSolver:
             They probably have not been stored by the solver because the option keep_details=True have not been set.
             Please re-run the resolution with this option.""")
 
-        _, gradG = self.green_function.evaluate(points, result.body.mesh, result.free_surface, result.sea_bottom, result.wavenumber,
+        _, gradG = self.green_function.evaluate(points, result.body.mesh, result.free_surface, -result.water_depth, result.wavenumber,
                                                 early_dot_product=False)
         velocities = np.einsum('ijk,j->ik', gradG, result.sources)  # Sum the contributions of all panels in the mesh
         return velocities.reshape((*output_shape, 3))
@@ -328,7 +328,7 @@ class BEMSolver:
             S = self.engine.build_S_matrix(
                 mesh,
                 result.body.mesh,
-                result.free_surface, result.sea_bottom, result.wavenumber,
+                result.free_surface, -result.water_depth, result.wavenumber,
                 self.green_function
             )
             phi = S @ result.sources
@@ -340,7 +340,7 @@ class BEMSolver:
                 S = self.engine.build_S_matrix(
                     mesh.extract_faces(faces_to_extract),
                     result.body.mesh,
-                    result.free_surface, result.sea_bottom, result.wavenumber,
+                    result.free_surface, -result.water_depth, result.wavenumber,
                     self.green_function
                 )
                 phi[i:i+chunk_size] = S @ result.sources

--- a/capytaine/bodies/bodies.py
+++ b/capytaine/bodies/bodies.py
@@ -14,7 +14,7 @@ import xarray as xr
 from capytaine.tools.optional_imports import silently_import_optional_dependency
 meshio = silently_import_optional_dependency("meshio")
 
-from capytaine.meshes.geometry import Abstract3DObject, Plane, inplace_transformation
+from capytaine.meshes.geometry import Abstract3DObject, ClippableMixin, Plane, inplace_transformation
 from capytaine.meshes.meshes import Mesh
 from capytaine.meshes.symmetric import build_regular_array_of_meshes
 from capytaine.meshes.collections import CollectionOfMeshes
@@ -26,7 +26,7 @@ TRANSLATION_DOFS_DIRECTIONS = {"surge": (1, 0, 0), "sway": (0, 1, 0), "heave": (
 ROTATION_DOFS_AXIS = {"roll": (1, 0, 0), "pitch": (0, 1, 0), "yaw": (0, 0, 1)}
 
 
-class FloatingBody(Abstract3DObject):
+class FloatingBody(ClippableMixin, Abstract3DObject):
     """A floating body described as a mesh and some degrees of freedom.
 
     The mesh structure is stored as a Mesh from capytaine.mesh.mesh or a
@@ -961,20 +961,6 @@ respective inertia coefficients are assigned as NaN.")
                 self.dofs[dof] = np.empty((0, 3))
         return self
 
-    def clipped(self, plane, **kwargs):
-        # Same API as for the other transformations
-        return self.clip(plane, inplace=False, **kwargs)
-
-    @inplace_transformation
-    def keep_immersed_part(self, free_surface=0.0, sea_bottom=-np.infty):
-        """Remove the parts of the mesh above the sea bottom and below the free surface."""
-        self.clip(Plane(normal=(0, 0, 1), point=(0, 0, free_surface)))
-        if sea_bottom > -np.infty:
-            self.clip(Plane(normal=(0, 0, -1), point=(0, 0, sea_bottom)))
-        return self
-
-    def immersed_part(self, free_surface=0.0, sea_bottom=-np.infty):
-        return self.keep_immersed_part(free_surface, sea_bottom, inplace=False, name=self.name)
 
     #############
     #  Display  #

--- a/capytaine/io/legacy.py
+++ b/capytaine/io/legacy.py
@@ -25,11 +25,9 @@ def import_cal_file(filepath):
         cal_file.readline()  # Unused line.
         rho = float(cal_file.readline().split()[0])
         g = float(cal_file.readline().split()[0])
-        depth = float(cal_file.readline().split()[0])
-        if depth == 0.0:
-            sea_bottom = -np.infty
-        else:
-            sea_bottom = -depth
+        water_depth = float(cal_file.readline().split()[0])
+        if water_depth == 0.0:
+            water_depth = np.infty
         xeff, yeff = (float(x) for x in cal_file.readline().split()[0:2])
 
         bodies = []
@@ -114,7 +112,7 @@ def import_cal_file(filepath):
         free_surface_data = cal_file.readline().split()
 
     # Generate Capytaine's problem objects
-    env_args = dict(body=bodies, rho=rho, sea_bottom=sea_bottom, g=g)
+    env_args = dict(body=bodies, rho=rho, water_depth=water_depth, g=g)
     problems = []
     for omega in omega_range:
         for direction in direction_range:

--- a/capytaine/io/legacy.py
+++ b/capytaine/io/legacy.py
@@ -171,7 +171,7 @@ def export_as_Nemoh_directory(problem, directory_name, omega_range=None):
                 DEFAULT_NEMOH_CAL.format(
                     rho=problem.rho,
                     g=problem.g,
-                    depth=problem.depth if problem.depth < np.infty else 0,
+                    depth=problem.water_depth if problem.water_depth < np.infty else 0,
                     mesh_filename=f'{problem.body.name}.dat',
                     mesh_vertices=problem.body.mesh.nb_vertices,
                     mesh_faces=problem.body.mesh.nb_faces,

--- a/capytaine/io/xarray.py
+++ b/capytaine/io/xarray.py
@@ -190,7 +190,7 @@ def wavenumber_data_array(results: Sequence[LinearPotentialFlowResult]) -> xr.Da
     and store them into a :class:`xarray.DataArray`.
     """
     records = pd.DataFrame(
-        [dict(g=result.g, water_depth=result.depth, omega=result.omega, wavenumber=result.wavenumber)
+        [dict(g=result.g, water_depth=result.water_depth, omega=result.omega, wavenumber=result.wavenumber)
          for result in results]
     )
     ds = _dataset_from_dataframe(records, variables=['wavenumber'], dimensions=['omega'], optional_dims=['g', 'water_depth'])

--- a/capytaine/io/xarray.py
+++ b/capytaine/io/xarray.py
@@ -114,7 +114,7 @@ def problems_from_dataset(dataset: xr.Dataset,
                 in product(freq_range, wave_direction_range, water_depth_range, body_range, rho_range, g_range):
             problems.append(
                 DiffractionProblem(body=body_range[body_name], **{freq_type: freq},
-                                   wave_direction=wave_direction, sea_bottom=-water_depth, rho=rho, g=g)
+                                   wave_direction=wave_direction, water_depth=water_depth, rho=rho, g=g)
             )
 
     if radiating_dofs is not None:
@@ -122,7 +122,7 @@ def problems_from_dataset(dataset: xr.Dataset,
                 in product(freq_range, radiating_dofs, water_depth_range, body_range, rho_range, g_range):
             problems.append(
                 RadiationProblem(body=body_range[body_name], **{freq_type: freq},
-                                 radiating_dof=radiating_dof, sea_bottom=-water_depth, rho=rho, g=g)
+                                 radiating_dof=radiating_dof, water_depth=water_depth, rho=rho, g=g)
             )
 
     return sorted(problems)

--- a/capytaine/meshes/collections.py
+++ b/capytaine/meshes/collections.py
@@ -12,14 +12,14 @@ from typing import Iterable, Union
 
 import numpy as np
 
-from capytaine.meshes.geometry import Abstract3DObject, inplace_transformation
+from capytaine.meshes.geometry import Abstract3DObject, ClippableMixin, inplace_transformation
 from capytaine.meshes.surface_integrals import SurfaceIntegralsMixin
 from capytaine.meshes.meshes import Mesh
 
 LOG = logging.getLogger(__name__)
 
 
-class CollectionOfMeshes(SurfaceIntegralsMixin, Abstract3DObject):
+class CollectionOfMeshes(ClippableMixin, SurfaceIntegralsMixin, Abstract3DObject):
     """A tuple of meshes.
     It gives access to all the vertices of all the sub-meshes as if it were a mesh itself.
     Collections can be nested to store meshes in a tree structure.
@@ -255,23 +255,10 @@ class CollectionOfMeshes(SurfaceIntegralsMixin, Abstract3DObject):
         self._clipping_data['faces_ids'] = np.asarray(self._clipping_data['faces_ids'])
         self.prune_empty_meshes()
 
-    def clipped(self, plane, **kwargs):
-        # Same API as for the other transformations
-        return self.clip(plane, inplace=False, **kwargs)
-
     def symmetrized(self, plane):
         from capytaine.meshes.symmetric import ReflectionSymmetricMesh
         half = self.clipped(plane, name=f"{self.name}_half")
         return ReflectionSymmetricMesh(half, plane=plane, name=f"symmetrized_of_{self.name}")
-
-    @inplace_transformation
-    def keep_immersed_part(self, *args, **kwargs):
-        for mesh in self:
-            mesh.keep_immersed_part(*args, **kwargs)
-        self.prune_empty_meshes()
-
-    def immersed_part(self, free_surface=0.0, sea_bottom=-np.infty):
-        return self.keep_immersed_part(free_surface, sea_bottom, inplace=False)
 
     @inplace_transformation
     def prune_empty_meshes(self):

--- a/capytaine/meshes/meshes.py
+++ b/capytaine/meshes/meshes.py
@@ -12,7 +12,7 @@ from itertools import count
 import numpy as np
 from numpy.linalg import norm
 
-from capytaine.meshes.geometry import Abstract3DObject, Plane, inplace_transformation
+from capytaine.meshes.geometry import Abstract3DObject, ClippableMixin, Plane, inplace_transformation
 from capytaine.meshes.properties import compute_faces_properties
 from capytaine.meshes.surface_integrals import SurfaceIntegralsMixin
 from capytaine.meshes.quality import (merge_duplicates, heal_normals, remove_unused_vertices,
@@ -22,7 +22,7 @@ from capytaine.tools.optional_imports import import_optional_dependency
 LOG = logging.getLogger(__name__)
 
 
-class Mesh(SurfaceIntegralsMixin, Abstract3DObject):
+class Mesh(ClippableMixin, SurfaceIntegralsMixin, Abstract3DObject):
     """A class to handle unstructured 2D meshes in a 3D space.
 
     Parameters
@@ -637,22 +637,6 @@ class Mesh(SurfaceIntegralsMixin, Abstract3DObject):
         self.faces = clipped_self.faces
         self._clipping_data = clipped_self._clipping_data
         return self
-
-    def clipped(self, plane, **kwargs) -> 'Mesh':
-        # Same API as for the other transformations
-        return self.clip(plane, inplace=False, **kwargs)
-
-    @inplace_transformation
-    def keep_immersed_part(self, free_surface=0.0, sea_bottom=-np.infty):
-        """Clip the mesh with two horizontal planes corresponding
-        with the free surface and the sea bottom."""
-        self.clip(Plane(normal=(0, 0, 1), point=(0, 0, free_surface)))
-        if sea_bottom > -np.infty:
-            self.clip(Plane(normal=(0, 0, -1), point=(0, 0, sea_bottom)))
-        return self
-
-    def immersed_part(self, free_surface=0.0, sea_bottom=-np.infty):
-        return self.keep_immersed_part(free_surface, sea_bottom, inplace=False, name=self.name)
 
     @inplace_transformation
     def triangulate_quadrangles(self) -> 'Mesh':

--- a/capytaine/post_pro/kochin.py
+++ b/capytaine/post_pro/kochin.py
@@ -31,7 +31,7 @@ def compute_kochin(result, theta, ref_point=(0.0, 0.0)):
         Please re-run the resolution with this option.""")
 
     k = result.wavenumber
-    h = result.depth
+    h = result.water_depth
 
     # omega_bar.shape = (nb_faces, 2) @ (2, nb_theta)
     omega_bar = (result.body.mesh.faces_centers[:, 0:2] - ref_point) @ (np.cos(theta), np.sin(theta))

--- a/capytaine/tools/deprecation_handling.py
+++ b/capytaine/tools/deprecation_handling.py
@@ -1,0 +1,16 @@
+import logging
+
+import numpy as np
+
+LOG = logging.getLogger(__name__)
+
+def _get_water_depth(free_surface, water_depth, sea_bottom, default_water_depth=np.infty):
+    if water_depth is None and sea_bottom is None:
+        return default_water_depth
+    elif water_depth is not None and sea_bottom is None:
+        return float(water_depth)
+    elif water_depth is None and sea_bottom is not None:
+        LOG.warning("Deprecation warning: please prefer giving a `water_depth` rather than a `sea_bottom`.")
+        return float(free_surface - sea_bottom)
+    else:
+        raise ValueError("Cannot give both a `water_depth` and a `sea_bottom`.")

--- a/capytaine/tools/deprecation_handling.py
+++ b/capytaine/tools/deprecation_handling.py
@@ -10,7 +10,7 @@ def _get_water_depth(free_surface, water_depth, sea_bottom, default_water_depth=
     elif water_depth is not None and sea_bottom is None:
         return float(water_depth)
     elif water_depth is None and sea_bottom is not None:
-        LOG.warning("Deprecation warning: please prefer giving a `water_depth` rather than a `sea_bottom`.")
+        LOG.warning("To uniformize notations througouth Capytaine, setting `water_depth` is preferred to `sea_bottom` since version 2.0.")
         return float(free_surface - sea_bottom)
     else:
         raise ValueError("Cannot give both a `water_depth` and a `sea_bottom`.")

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,8 @@ Major changes
 
 * Add methods :meth:`~capytaine.bem.solver.compute_potential`, :meth:`~capytaine.bem.solver.compute_velocity` and :meth:`~capytaine.bem.solver.compute_free_surface_elevation` and :meth:`~capytaine.bem.solver.compute_pressure` to compute the value of some fields in the domain in post-processing. Their signature has been uniformized with the :func:`~capytaine.bem.airy_waves.airy_waves_potential`, :func:`~capytaine.bem.airy_waves.airy_waves_velocity`, :func:`~capytaine.bem.airy_waves.airy_waves_free_surface_elevation` and :func:`~capytaine.bem.airy_waves.airy_waves_pressure` functions (:pull:`288`, :pull:`326`)
 
+* The problems can now be initialized by setting a ``water_depth`` instead of the ``sea_bottom``. This change is meant to uniformize notations in the code and use ``water_depth`` wherever possible. (:pull:`340`)
+
 Minor changes
 ~~~~~~~~~~~~~
 

--- a/docs/user_manual/examples/finite_depth_cylinder.py
+++ b/docs/user_manual/examples/finite_depth_cylinder.py
@@ -27,7 +27,7 @@ depth_range = list(range(5, 25, 2)) + [np.infty]
 # Set up the problems: we will solve a radiation problem for each
 # water depth:
 problems = [
-    cpt.RadiationProblem(body=body, sea_bottom=-depth, omega=2.0)
+    cpt.RadiationProblem(body=body, water_depth=depth, omega=2.0)
     for depth in depth_range
 ]
 # Water density, gravity and radiating dof have not been specified.

--- a/docs/user_manual/examples/haskind.py
+++ b/docs/user_manual/examples/haskind.py
@@ -22,9 +22,9 @@ body = body.immersed_part()
 solver = cpt.BEMSolver()
 
 # Define and solve the diffraction and radiation problems
-diff_problem = cpt.DiffractionProblem(body=body, sea_bottom=-depth,
+diff_problem = cpt.DiffractionProblem(body=body, water_depth=depth,
                                       omega=omega, wave_direction=0.)
-rad_problem = cpt.RadiationProblem(body=body, sea_bottom=-depth,
+rad_problem = cpt.RadiationProblem(body=body, water_depth=depth,
                                    omega=omega, radiating_dof='Heave')
 
 diff_solution = solver.solve(diff_problem)

--- a/docs/user_manual/problem_setup.rst
+++ b/docs/user_manual/problem_setup.rst
@@ -56,7 +56,7 @@ The table below gives their definitions and their default values.
 +=======================+==========================================+========================+
 | :code:`free_surface`  | Position of the free surface [#]_ (m)    | :math:`0.0` m          |
 +-----------------------+------------------------------------------+------------------------+
-| :code:`water_depth`   | Depth of water (m)                       | :math:`\infty` m      |
+| :code:`water_depth`   | Constant depth of water (m)              | :math:`\infty` m      |
 +-----------------------+------------------------------------------+------------------------+
 | :code:`g`             | Acceleration of gravity :math:`g` (m/s²) | :math:`9.81` m/s²      |
 +-----------------------+------------------------------------------+------------------------+
@@ -111,14 +111,6 @@ Once the problem has been initialized, the other parameters can be retrieved as:
    magnitudes are recomputed from the stored :code:`omega`. Hence small
    rounding error might happend between the value provided by the user and the
    one used by Capytaine.
-
-Besides, the following attributes are also accessible:
-
-+------------------------------------+-------------------------------------------------+
-| Parameter                          | Description (unit)                              |
-+====================================+=================================================+
-| :code:`depth`                      | Water depth :math:`h` (m)                       |
-+------------------------------------+-------------------------------------------------+
 
 
 Legacy Nemoh.cal parameters files

--- a/docs/user_manual/problem_setup.rst
+++ b/docs/user_manual/problem_setup.rst
@@ -56,7 +56,7 @@ The table below gives their definitions and their default values.
 +=======================+==========================================+========================+
 | :code:`free_surface`  | Position of the free surface [#]_ (m)    | :math:`0.0` m          |
 +-----------------------+------------------------------------------+------------------------+
-| :code:`sea_bottom`    | Position of the sea bottom (m)           | :math:`-\infty` m      |
+| :code:`water_depth`   | Depth of water (m)                       | :math:`\infty` m      |
 +-----------------------+------------------------------------------+------------------------+
 | :code:`g`             | Acceleration of gravity :math:`g` (m/s²) | :math:`9.81` m/s²      |
 +-----------------------+------------------------------------------+------------------------+

--- a/docs/user_manual/tutorial.rst
+++ b/docs/user_manual/tutorial.rst
@@ -172,7 +172,7 @@ Defining linear potential flow problems.
 Let us define a radiation problem for the heave of our sphere::
 
     from numpy import infty
-    problem = cpt.RadiationProblem(body=body, radiating_dof="Heave", omega=1.0, sea_bottom=-infty, g=9.81, rho=1000)
+    problem = cpt.RadiationProblem(body=body, radiating_dof="Heave", omega=1.0, water_depth=infty, g=9.81, rho=1000)
 
 The argument :code:`radiating_dof` must be the name of one of the dofs of the floating body given as the
 :code:`body` argument. The wave angular frequency has been set arbitrarily as :math:`\omega = 1 \, \text{rad/s}`.

--- a/pytest/test_bem_engines.py
+++ b/pytest/test_bem_engines.py
@@ -39,7 +39,7 @@ def test_cache_matrices():
 
 def test_custom_linear_solver():
     """Solve a simple problem with a custom linear solver."""
-    problem = RadiationProblem(body=sphere, omega=1.0, sea_bottom=-np.infty)
+    problem = RadiationProblem(body=sphere, omega=1.0, water_depth=np.infty)
 
     reference_solver = BEMSolver(
         engine=BasicMatrixEngine(linear_solver="gmres", matrix_cache_size=0)

--- a/pytest/test_bem_hierarchical_toeplitz_matrices.py
+++ b/pytest/test_bem_hierarchical_toeplitz_matrices.py
@@ -39,7 +39,7 @@ def test_floating_sphere(depth, omega):
 
     full_sphere = Sphere(radius=1.0, ntheta=reso, nphi=4*reso, axial_symmetry=False, clip_free_surface=True)
     full_sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
-    problem = RadiationProblem(body=full_sphere, omega=omega, sea_bottom=-depth)
+    problem = RadiationProblem(body=full_sphere, omega=omega, water_depth=depth)
     result1 = solver_with_sym.solve(problem)
 
     half_sphere_mesh = full_sphere.mesh.extract_faces(
@@ -47,7 +47,7 @@ def test_floating_sphere(depth, omega):
         name="half_sphere_mesh")
     two_halves_sphere = FloatingBody(ReflectionSymmetricMesh(half_sphere_mesh, xOz_Plane))
     two_halves_sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
-    problem = RadiationProblem(body=two_halves_sphere, omega=omega, sea_bottom=-depth)
+    problem = RadiationProblem(body=two_halves_sphere, omega=omega, water_depth=depth)
     result2 = solver_with_sym.solve(problem)
 
     quarter_sphere_mesh = half_sphere_mesh.extract_faces(
@@ -56,12 +56,12 @@ def test_floating_sphere(depth, omega):
     four_quarter_sphere = FloatingBody(ReflectionSymmetricMesh(ReflectionSymmetricMesh(quarter_sphere_mesh, yOz_Plane), xOz_Plane))
     assert 'None' not in four_quarter_sphere.mesh.tree_view()
     four_quarter_sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
-    problem = RadiationProblem(body=four_quarter_sphere, omega=omega, sea_bottom=-depth)
+    problem = RadiationProblem(body=four_quarter_sphere, omega=omega, water_depth=depth)
     result3 = solver_with_sym.solve(problem)
 
     clever_sphere = Sphere(radius=1.0, ntheta=reso, nphi=4*reso, axial_symmetry=True, clip_free_surface=True)
     clever_sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
-    problem = RadiationProblem(body=clever_sphere, omega=omega, sea_bottom=-depth)
+    problem = RadiationProblem(body=clever_sphere, omega=omega, water_depth=depth)
     result4 = solver_with_sym.solve(problem)
 
     # (quarter_sphere + half_sphere + full_sphere + clever_sphere).show()
@@ -126,7 +126,7 @@ def test_horizontal_cylinder(depth):
     assert isinstance(cylinder.mesh, Mesh)
     cylinder.translate_z(-3.0)
     cylinder.add_translation_dof(direction=(0, 0, 1), name="Heave")
-    problem = RadiationProblem(body=cylinder, omega=1.0, sea_bottom=-depth)
+    problem = RadiationProblem(body=cylinder, omega=1.0, water_depth=depth)
     result1 = solver_with_sym.solve(problem)
 
     trans_cylinder = HorizontalCylinder(length=10.0, radius=1.0, reflection_symmetry=False, translation_symmetry=True, nr=2, ntheta=10, nx=10)
@@ -134,7 +134,7 @@ def test_horizontal_cylinder(depth):
     assert isinstance(trans_cylinder.mesh[0], TranslationalSymmetricMesh)
     trans_cylinder.translate_z(-3.0)
     trans_cylinder.add_translation_dof(direction=(0, 0, 1), name="Heave")
-    problem = RadiationProblem(body=trans_cylinder, omega=1.0, sea_bottom=-depth)
+    problem = RadiationProblem(body=trans_cylinder, omega=1.0, water_depth=depth)
     result2 = solver_with_sym.solve(problem)
 
     # S, V = solver_with_sym.build_matrices(trans_cylinder.mesh, trans_cylinder.mesh)
@@ -205,7 +205,7 @@ def test_array_of_spheres():
     assert np.allclose(S.full_matrix(), fullS)
     assert np.allclose(V.full_matrix(), fullV)
 
-    problem = RadiationProblem(body=array, omega=1.0, radiating_dof="2_0__Heave", sea_bottom=-np.infty)
+    problem = RadiationProblem(body=array, omega=1.0, radiating_dof="2_0__Heave", water_depth=np.infty)
 
     result = solver_with_sym.solve(problem)
     result2 = solver_without_sym.solve(problem)

--- a/pytest/test_bem_problems_and_results.py
+++ b/pytest/test_bem_problems_and_results.py
@@ -79,9 +79,11 @@ def test_LinearPotentialFlowProblem():
     assert res.period == pb.period
     assert res.body is pb.body
 
-def test_backward_compatibility_with_sea_bottom_argument():
-    pb = cpt.DiffractionProblem(sea_bottom=-10.0)
-    assert pb.water_depth == 10.0
+def test_backward_compatibility_with_sea_bottom_argument(caplog):
+    with caplog.at_level(logging.WARNING):
+        pb = cpt.DiffractionProblem(sea_bottom=-10.0)
+        assert pb.water_depth == 10.0
+    assert 'water_depth' in caplog.text
 
 @pytest.mark.parametrize("water_depth", [10.0, np.infty])
 def test_setting_wavelength(water_depth):

--- a/pytest/test_bem_problems_and_results.py
+++ b/pytest/test_bem_problems_and_results.py
@@ -79,6 +79,9 @@ def test_LinearPotentialFlowProblem():
     assert res.period == pb.period
     assert res.body is pb.body
 
+def test_backward_compatibility_with_sea_bottom_argument():
+    pb = cpt.DiffractionProblem(sea_bottom=-10.0)
+    assert pb.water_depth == 10.0
 
 @pytest.mark.parametrize("water_depth", [10.0, np.infty])
 def test_setting_wavelength(water_depth):

--- a/pytest/test_bem_problems_and_results.py
+++ b/pytest/test_bem_problems_and_results.py
@@ -35,12 +35,12 @@ def test_LinearPotentialFlowProblem():
     assert pb.wavenumber == 1.0/9.81
     assert pb.wavelength == 9.81*2*np.pi
 
-    assert LinearPotentialFlowProblem(free_surface=np.infty, sea_bottom=-np.infty).depth == np.infty
-    assert LinearPotentialFlowProblem(free_surface=0.0, sea_bottom=-np.infty).depth == np.infty
+    assert LinearPotentialFlowProblem(free_surface=np.infty, sea_bottom=-np.infty).water_depth == np.infty
+    assert LinearPotentialFlowProblem(free_surface=0.0, sea_bottom=-np.infty).water_depth == np.infty
 
     pb = LinearPotentialFlowProblem(free_surface=0.0, sea_bottom=-1.0, omega=1.0)
-    assert pb.depth == 1.0
-    assert np.isclose(pb.omega**2, pb.g*pb.wavenumber*np.tanh(pb.wavenumber*pb.depth))
+    assert pb.water_depth == 1.0
+    assert np.isclose(pb.omega**2, pb.g*pb.wavenumber*np.tanh(pb.wavenumber*pb.water_depth))
 
     with pytest.raises(NotImplementedError):
         LinearPotentialFlowProblem(free_surface=2.0)
@@ -181,7 +181,7 @@ def test_import_cal_file(cal_file):
     for problem in problems:
         assert problem.rho == 1000.0
         assert problem.g == 9.81
-        assert problem.depth == np.infty
+        assert problem.water_depth == np.infty
         assert isinstance(problem.body, FloatingBody)
         assert problem.body.nb_dofs == 6
         assert problem.body.mesh.nb_vertices == 299  # Duplicate vertices are removed during import.
@@ -198,7 +198,7 @@ def test_import_cal_file(cal_file):
     for problem in problems:
         assert problem.rho == 1000.0
         assert problem.g == 9.81
-        assert problem.depth == np.infty
+        assert problem.water_depth == np.infty
         assert isinstance(problem.body.mesh, ReflectionSymmetricMesh)
         assert isinstance(problem.body.mesh[0], Mesh)
         assert problem.body.nb_dofs == 6

--- a/pytest/test_bem_problems_and_results.py
+++ b/pytest/test_bem_problems_and_results.py
@@ -35,10 +35,10 @@ def test_LinearPotentialFlowProblem():
     assert pb.wavenumber == 1.0/9.81
     assert pb.wavelength == 9.81*2*np.pi
 
-    assert LinearPotentialFlowProblem(free_surface=np.infty, sea_bottom=-np.infty).water_depth == np.infty
-    assert LinearPotentialFlowProblem(free_surface=0.0, sea_bottom=-np.infty).water_depth == np.infty
+    assert LinearPotentialFlowProblem(free_surface=np.infty, water_depth=np.infty).water_depth == np.infty
+    assert LinearPotentialFlowProblem(free_surface=0.0, water_depth=np.infty).water_depth == np.infty
 
-    pb = LinearPotentialFlowProblem(free_surface=0.0, sea_bottom=-1.0, omega=1.0)
+    pb = LinearPotentialFlowProblem(free_surface=0.0, water_depth=1.0, omega=1.0)
     assert pb.water_depth == 1.0
     assert np.isclose(pb.omega**2, pb.g*pb.wavenumber*np.tanh(pb.wavenumber*pb.water_depth))
 
@@ -46,10 +46,10 @@ def test_LinearPotentialFlowProblem():
         LinearPotentialFlowProblem(free_surface=2.0)
 
     with pytest.raises(NotImplementedError):
-        LinearPotentialFlowProblem(free_surface=np.infty, sea_bottom=0.0)
+        LinearPotentialFlowProblem(free_surface=np.infty, water_depth=2.0)
 
     with pytest.raises(ValueError):
-        LinearPotentialFlowProblem(free_surface=0.0, sea_bottom=1.0)
+        LinearPotentialFlowProblem(free_surface=0.0, water_depth=-1.0)
 
     with pytest.raises(TypeError):
         LinearPotentialFlowProblem(wave_direction=1.0)
@@ -83,17 +83,17 @@ def test_LinearPotentialFlowProblem():
 @pytest.mark.parametrize("water_depth", [10.0, np.infty])
 def test_setting_wavelength(water_depth):
     λ = 10*np.random.rand()
-    assert np.isclose(cpt.DiffractionProblem(wavelength=λ, sea_bottom=-water_depth).wavelength, λ)
+    assert np.isclose(cpt.DiffractionProblem(wavelength=λ, water_depth=water_depth).wavelength, λ)
 
 @pytest.mark.parametrize("water_depth", [10.0, np.infty])
 def test_setting_wavenumber(water_depth):
     k = 10*np.random.rand()
-    assert np.isclose(cpt.DiffractionProblem(wavenumber=k, sea_bottom=-water_depth).wavenumber, k)
+    assert np.isclose(cpt.DiffractionProblem(wavenumber=k, water_depth=water_depth).wavenumber, k)
 
 @pytest.mark.parametrize("water_depth", [10.0, np.infty])
 def test_setting_period(water_depth):
     T = 10*np.random.rand()
-    assert np.isclose(cpt.DiffractionProblem(period=T, sea_bottom=-water_depth).period, T)
+    assert np.isclose(cpt.DiffractionProblem(period=T, water_depth=water_depth).period, T)
 
 def test_setting_too_many_frequencies():
     with pytest.raises(ValueError, match="at most one"):
@@ -158,13 +158,13 @@ def test_Froude_Krylov():
     sphere = Sphere(radius=1.0, ntheta=3, nphi=12, clever=True, clip_free_surface=True)
     sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
 
-    problem = DiffractionProblem(body=sphere, omega=1.0, sea_bottom=-np.infty)
+    problem = DiffractionProblem(body=sphere, omega=1.0, water_depth=np.infty)
     assert np.isclose(froude_krylov_force(problem)['Heave'], 27596, rtol=1e-3)
 
-    problem = DiffractionProblem(body=sphere, omega=2.0, sea_bottom=-np.infty)
+    problem = DiffractionProblem(body=sphere, omega=2.0, water_depth=np.infty)
     assert np.isclose(froude_krylov_force(problem)['Heave'], 22491, rtol=1e-3)
 
-    problem = DiffractionProblem(body=sphere, omega=1.0, sea_bottom=-10.0)
+    problem = DiffractionProblem(body=sphere, omega=1.0, water_depth=10.0)
     assert np.isclose(froude_krylov_force(problem)['Heave'], 27610, rtol=1e-3)
 
 

--- a/pytest/test_bem_solver.py
+++ b/pytest/test_bem_solver.py
@@ -47,15 +47,15 @@ def test_limit_frequencies():
     """Test if how the solver answers when asked for frequency of 0 or ∞."""
     solver = BEMSolver()
 
-    solver.solve(RadiationProblem(body=sphere, omega=0.0, sea_bottom=-np.infty))
+    solver.solve(RadiationProblem(body=sphere, omega=0.0, water_depth=np.infty))
 
     with pytest.raises(NotImplementedError):
-        solver.solve(RadiationProblem(body=sphere, omega=0.0, sea_bottom=-1.0))
+        solver.solve(RadiationProblem(body=sphere, omega=0.0, water_depth=1.0))
 
-    solver.solve(RadiationProblem(body=sphere, omega=np.infty, sea_bottom=-np.infty))
+    solver.solve(RadiationProblem(body=sphere, omega=np.infty, water_depth=np.infty))
 
     with pytest.raises(NotImplementedError):
-        solver.solve(RadiationProblem(body=sphere, omega=np.infty, sea_bottom=-10))
+        solver.solve(RadiationProblem(body=sphere, omega=np.infty, water_depth=10))
 
 
 @pytest.mark.skipif(joblib is None, reason='joblib is not installed')

--- a/pytest/test_bodies.py
+++ b/pytest/test_bodies.py
@@ -122,7 +122,7 @@ def test_clipping_of_dofs(z_center, as_collection_of_meshes):
     axis = Axis(point=(1, 0, 0), vector=(1, 0, 0))
 
     full_sphere.add_rotation_dof(axis, name="test_dof")
-    clipped_sphere = full_sphere.keep_immersed_part(free_surface=0.0, sea_bottom=-np.infty, inplace=False)
+    clipped_sphere = full_sphere.keep_immersed_part(free_surface=0.0, water_depth=np.infty, inplace=False)
 
     other_clipped_sphere = FloatingBody(mesh=clipped_sphere.mesh, name="other_sphere")
     other_clipped_sphere.add_rotation_dof(axis, name="test_dof")

--- a/pytest/test_consistency_with_Nemoh_2.py
+++ b/pytest/test_consistency_with_Nemoh_2.py
@@ -27,14 +27,14 @@ def test_immersed_sphere():
     sphere.add_translation_dof(direction=(1, 0, 0), name="Surge")
     sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
 
-    problem = RadiationProblem(body=sphere, radiating_dof="Heave", free_surface=np.infty, sea_bottom=-np.infty)
+    problem = RadiationProblem(body=sphere, radiating_dof="Heave", free_surface=np.infty, water_depth=np.infty)
     result = solver.solve(problem)
     assert np.isclose(result.added_masses["Heave"],       2187, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.added_masses["Surge"],        0.0, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.radiation_dampings["Heave"],  0.0, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.radiation_dampings["Surge"],  0.0, atol=1e-3*sphere.volume*problem.rho)
 
-    problem = RadiationProblem(body=sphere, radiating_dof="Surge", free_surface=np.infty, sea_bottom=-np.infty)
+    problem = RadiationProblem(body=sphere, radiating_dof="Surge", free_surface=np.infty, water_depth=np.infty)
     result = solver.solve(problem)
     assert np.isclose(result.added_masses["Surge"],       2194, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.added_masses["Heave"],        0.0, atol=1e-3*sphere.volume*problem.rho)
@@ -71,7 +71,7 @@ def test_floating_sphere_finite_freq():
     sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
 
     # omega = 1, radiation
-    problem = RadiationProblem(body=sphere, omega=1.0, sea_bottom=-np.infty)
+    problem = RadiationProblem(body=sphere, omega=1.0, water_depth=np.infty)
     result = solver.solve(problem, keep_details=True)
     assert np.isclose(result.added_masses["Heave"],       1819.6, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.radiation_dampings["Heave"], 379.39, atol=1e-3*sphere.volume*problem.rho)
@@ -89,7 +89,7 @@ def test_floating_sphere_finite_freq():
     assert np.allclose(eta, ref, rtol=1e-4)
 
     # omega = 1, diffraction
-    problem = DiffractionProblem(body=sphere, omega=1.0, sea_bottom=-np.infty)
+    problem = DiffractionProblem(body=sphere, omega=1.0, water_depth=np.infty)
     result = solver.solve(problem, keep_details=True)
     assert np.isclose(result.forces["Heave"], 1834.9 * np.exp(-2.933j), rtol=1e-3)
 
@@ -108,13 +108,13 @@ def test_floating_sphere_finite_freq():
     assert np.allclose(kochin, ref_kochin, rtol=1e-3)
 
     # omega = 2, radiation
-    problem = RadiationProblem(body=sphere, omega=2.0, sea_bottom=-np.infty)
+    problem = RadiationProblem(body=sphere, omega=2.0, water_depth=np.infty)
     result = solver.solve(problem)
     assert np.isclose(result.added_masses["Heave"],       1369.3, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.radiation_dampings["Heave"], 1425.6, atol=1e-3*sphere.volume*problem.rho)
 
     # omega = 2, diffraction
-    problem = DiffractionProblem(body=sphere, omega=2.0, sea_bottom=-np.infty)
+    problem = DiffractionProblem(body=sphere, omega=2.0, water_depth=np.infty)
     result = solver.solve(problem)
     assert np.isclose(result.forces["Heave"], 5846.6 * np.exp(-2.623j), rtol=1e-3)
 
@@ -133,7 +133,7 @@ def test_alien_sphere():
     assert np.isclose(result.radiation_dampings["Heave"], 309, atol=1e-3*sphere.volume*problem.rho)
 
     # diffraction
-    problem = DiffractionProblem(body=sphere, rho=450.0, g=1.625, omega=1.0, sea_bottom=-np.infty)
+    problem = DiffractionProblem(body=sphere, rho=450.0, g=1.625, omega=1.0, water_depth=np.infty)
     result = solver.solve(problem)
     assert np.isclose(result.forces["Heave"], 548.5 * np.exp(-2.521j), rtol=1e-2)
 
@@ -144,7 +144,7 @@ def test_floating_sphere_finite_depth():
     sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
 
     # omega = 1, radiation
-    problem = RadiationProblem(body=sphere, omega=1.0, radiating_dof="Heave", sea_bottom=-10.0)
+    problem = RadiationProblem(body=sphere, omega=1.0, radiating_dof="Heave", water_depth=10.0)
     result = solver.solve(problem, keep_details=True)
     assert np.isclose(result.added_masses["Heave"],       1740.6, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.radiation_dampings["Heave"], 380.46, atol=1e-3*sphere.volume*problem.rho)
@@ -154,18 +154,18 @@ def test_floating_sphere_finite_depth():
     assert np.isclose(kochin[0], -0.2267+3.49e-3j, rtol=1e-3)
 
     # omega = 1, diffraction
-    problem = DiffractionProblem(body=sphere, omega=1.0, wave_direction=0.0, sea_bottom=-10.0)
+    problem = DiffractionProblem(body=sphere, omega=1.0, wave_direction=0.0, water_depth=10.0)
     result = solver.solve(problem)
     assert np.isclose(result.forces["Heave"], 1749.4 * np.exp(-2.922j), rtol=1e-3)
 
     # omega = 2, radiation
-    problem = RadiationProblem(body=sphere, omega=2.0, radiating_dof="Heave", sea_bottom=-10.0)
+    problem = RadiationProblem(body=sphere, omega=2.0, radiating_dof="Heave", water_depth=10.0)
     result = solver.solve(problem)
     assert np.isclose(result.added_masses["Heave"],       1375.0, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.radiation_dampings["Heave"], 1418.0, atol=1e-3*sphere.volume*problem.rho)
 
     # omega = 2, diffraction
-    problem = DiffractionProblem(body=sphere, omega=2.0, wave_direction=0.0, sea_bottom=-10.0)
+    problem = DiffractionProblem(body=sphere, omega=2.0, wave_direction=0.0, water_depth=10.0)
     result = solver.solve(problem)
     assert np.isclose(result.forces["Heave"], 5872.8 * np.exp(-2.627j), rtol=1e-3)
 
@@ -180,7 +180,7 @@ def test_two_distant_spheres_in_finite_depth():
     other_buoy = buoy.translated_x(20, name="other_buoy")
     both_buoys = buoy.join_bodies(other_buoy)
     both_buoys.add_translation_dof(name="Surge")
-    problem = RadiationProblem(body=both_buoys, radiating_dof="Surge", sea_bottom=-10, omega=7.0)
+    problem = RadiationProblem(body=both_buoys, radiating_dof="Surge", water_depth=10, omega=7.0)
     result = solver.solve(problem)
 
     total_volume = 2*4/3*np.pi*radius**3

--- a/pytest/test_meshes.py
+++ b/pytest/test_meshes.py
@@ -163,20 +163,19 @@ def test_clipper():
 
     mesh.keep_immersed_part(free_surface=0.0, water_depth=1.0)
     assert np.allclose(mesh.merged().axis_aligned_bbox, aabb[:4] + (-1, 0,))  # the last item of the tuple has changed
-    
+
     # Check boundaries after clipping
     mesh = mesh_rectangle(size=(5,5), normal=(1,0,0))
     assert max([i[2] for i in mesh.immersed_part(free_surface=-1).vertices])<=-1
     assert max([i[2] for i in mesh.immersed_part(free_surface= 1).vertices])<= 1
-    assert min([i[2] for i in mesh.immersed_part(free_surface=np.infty, sea_bottom=-1).vertices])>=-1
-    assert min([i[2] for i in mesh.immersed_part(free_surface=np.infty, sea_bottom= 1).vertices])>= 1
-    
+    assert min([i[2] for i in mesh.immersed_part(free_surface=100, sea_bottom=-1).vertices])>=-1
+    assert min([i[2] for i in mesh.immersed_part(free_surface=100, sea_bottom= 1).vertices])>= 1
+
     mesh = mesh_rectangle(size=(4,4), resolution=(1,1), normal=(1,0,0))
     tmp = list(mesh.clip(Plane(normal=(0,0.1,1),point=(0,0,-1)),inplace=False).vertices)
     tmp.sort(key=lambda x: x[2])
     tmp.sort(key=lambda x: x[1])
     assert np.allclose([i[2] for i in tmp], [-2, -0.8, -2, -1.2])
-    
 
 
 @pytest.mark.parametrize("size", [5, 6])

--- a/pytest/test_meshes.py
+++ b/pytest/test_meshes.py
@@ -147,20 +147,20 @@ def test_clipper():
     mesh = Sphere(radius=5.0, ntheta=10).mesh.merged()
     aabb = mesh.axis_aligned_bbox
 
-    mesh.keep_immersed_part(free_surface=0.0, sea_bottom=-np.infty)
+    mesh.keep_immersed_part(free_surface=0.0, water_depth=np.infty)
     assert np.allclose(mesh.axis_aligned_bbox, aabb[:5] + (0,))  # the last item of the tuple has changed
 
-    mesh.keep_immersed_part(free_surface=0.0, sea_bottom=-1.0)
+    mesh.keep_immersed_part(free_surface=0.0, water_depth=1.0)
     assert np.allclose(mesh.axis_aligned_bbox, aabb[:4] + (-1, 0,))  # the last item of the tuple has changed
 
     # With CollectionOfMeshes (AxialSymmetry)
     mesh = Sphere(radius=5.0, ntheta=10).mesh
     aabb = mesh.merged().axis_aligned_bbox
 
-    mesh.keep_immersed_part(free_surface=0.0, sea_bottom=-np.infty)
+    mesh.keep_immersed_part(free_surface=0.0, water_depth=np.infty)
     assert np.allclose(mesh.merged().axis_aligned_bbox, aabb[:5] + (0,))  # the last item of the tuple has changed
 
-    mesh.keep_immersed_part(free_surface=0.0, sea_bottom=-1.0)
+    mesh.keep_immersed_part(free_surface=0.0, water_depth=1.0)
     assert np.allclose(mesh.merged().axis_aligned_bbox, aabb[:4] + (-1, 0,))  # the last item of the tuple has changed
 
 


### PR DESCRIPTION
This change is meant to uniformize notations in the code and replace the use of `sea_bottom` by `water_depth`.

Related to #88.