### PR TITLE
Add minimal_computable_wavelength property to bodies.

### DIFF
--- a/capytaine/bem/problems_and_results.py
+++ b/capytaine/bem/problems_and_results.py
@@ -129,7 +129,7 @@ class LinearPotentialFlowProblem:
                     "or use body.keep_immersed_part() to clip the mesh."
                 )
 
-            if self.wavelength < 8*self.body.mesh.faces_radiuses.max():
+            if self.wavelength < self.body.minimal_computable_wavelength:
                 LOG.warning(f"Mesh resolution for {self}:\n"
                         f"The resolution of the mesh '{self.body.mesh.name}' of the body '{self.body.name}' "
                         f"might be insufficient for the wavelength λ={self.wavelength:.2e}.\n"

--- a/capytaine/bodies/bodies.py
+++ b/capytaine/bodies/bodies.py
@@ -1026,5 +1026,5 @@ respective inertia coefficients are assigned as NaN.")
 
     @property
     def minimal_computable_wavelength(self):
-        return 8*self.body.mesh.faces_radiuses.max()
+        return 8*self.mesh.faces_radiuses.max()
 

--- a/capytaine/bodies/bodies.py
+++ b/capytaine/bodies/bodies.py
@@ -1026,5 +1026,6 @@ respective inertia coefficients are assigned as NaN.")
 
     @property
     def minimal_computable_wavelength(self):
+        """For accuracy of the resolution, wavelength should not be smaller than this value."""
         return 8*self.mesh.faces_radiuses.max()
 

--- a/capytaine/bodies/bodies.py
+++ b/capytaine/bodies/bodies.py
@@ -1024,3 +1024,7 @@ respective inertia coefficients are assigned as NaN.")
         animation._add_actor(self.mesh.merged(), faces_motion=sum(motion[dof_name] * dof for dof_name, dof in self.dofs.items() if dof_name in motion))
         return animation
 
+    @property
+    def minimal_computable_wavelength(self):
+        return 8*self.body.mesh.faces_radiuses.max()
+

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,8 @@ Minor changes
 
 * Remove ``dimensionless_wavenumber`` and ``dimensionless_omega`` attributes from :class:`~capytaine.bem.problems_and_results.LinearPotentialFlowProblem` as they are not used in the code and can be easily recomputed by users if necessary (:pull:`306`).
 
+* Add :meth:`~capytaine.bodies.bodies.FloatingBody.minimal_computable_wavelength` to estimate the wavelengths computable with the mesh resolution (:pull:`341`).
+
 Bug fixes
 ~~~~~~~~~
 


### PR DESCRIPTION
It is meant to be used as a lower bound for wavelength ranges, in order to avoid the "insufficient mesh resolution" warnings.