### PR TITLE
Fix Windows wheel building

### DIFF
--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -39,10 +39,10 @@ jobs:
         uses: pypa/cibuildwheel@v2.12.3
         env:
           CIBW_SKIP: "pp* *i686* *musllinux* *win32*"
-        # # Package the DLL dependencies in the wheel for windows (done by default for the other platforms).
-        # # delvewheel cannot mangle the libraries, stripping does not work.
-        #   CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel
-        #   CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel show {wheel} && delvewheel repair -w {dest_dir} {wheel} --no-mangle-all"
+        # Package the DLL dependencies in the wheel for windows (done by default for the other platforms).
+        # delvewheel cannot mangle the libraries, stripping does not work.
+          CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel show {wheel} && delvewheel repair -w {dest_dir} {wheel} --no-mangle-all"
         # with:
         #   package-dir: .
         #   output-dir: wheelhouse

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -18,8 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [ubuntu-20.04, macos-11]
-        os: [windows-2019]
+        os: [ubuntu-20.04, macos-11, windows-2019]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -5,7 +5,7 @@ on:
   push:
     tags:
       - v*
-  # pull_request:
+  pull_request:
     # branches:
     #   - main
     # types:
@@ -18,7 +18,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11]
+        # os: [ubuntu-20.04, macos-11]
+        os: [windows-2019]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -5,7 +5,7 @@ on:
   push:
     tags:
       - v*
-  pull_request:
+  # pull_request:
     # branches:
     #   - main
     # types:

--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,7 @@ else
 endif
 
 args = ['-cpp']
-link_args = []
+link_args = ['-lquadmath']
 deps = [py3_dep, omp]
 
 py3.extension_module('Delhommeau_float32',

--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,7 @@ else
 endif
 
 args = ['-cpp']
-link_args = ['-lquadmath']
+link_args = ['-lquadmath']  # Required for the Windows build with cibuildwheel
 deps = [py3_dep, omp]
 
 py3.extension_module('Delhommeau_float32',

--- a/meson.build
+++ b/meson.build
@@ -1,9 +1,7 @@
 project('capytaine',
-  ['c'],
+  ['c', 'fortran'],
   version : run_command('capytaine/__about__.py', check: true).stdout().strip(),
   default_options : ['warning_level=2'])
-
-add_languages('fortran', native: false)
 
 py_mod = import('python')
 py3 = py_mod.find_installation('python3')

--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,9 @@
 project('capytaine',
-  ['c', 'fortran'],
+  ['c'],
   version : run_command('capytaine/__about__.py', check: true).stdout().strip(),
   default_options : ['warning_level=2'])
 
+add_languages('fortran', native: false)
 
 py_mod = import('python')
 py3 = py_mod.find_installation('python3')


### PR DESCRIPTION
Based on the following line from Scipy's meson.build file:
```meson
# Adding at project level causes many spurious -lgfortran flags.
add_languages('fortran', native: false)
```
I'm testing if it helps with my Windows compile issues.

Edit: it did not. But explicitely linking `quadmath` fixed the issue from #329
