### PR TITLE
Clipping - plane origin

### DIFF
--- a/capytaine/meshes/geometry.py
+++ b/capytaine/meshes/geometry.py
@@ -299,6 +299,11 @@ class Plane(Abstract3DObject):
         """Distance from plane to origin."""
         return np.linalg.norm(self.normal @ self.point)
 
+    @property
+    def s(self):
+        """Distance from origin to plane along the normal"""
+        return np.dot(self.normal, self.point)
+
     #################################
     #  Transformation of the plane  #
     #################################
@@ -365,7 +370,7 @@ class Plane(Abstract3DObject):
 
         p0n = np.dot(p0, self.normal)
         p1n = np.dot(p1, self.normal)
-        t = (p0n - self.c) / (p0n - p1n)
+        t = (p0n - self.s) / (p0n - p1n)
         if t < 0. or t > 1.:
             raise RuntimeError('Intersection is outside the edge')
         return (1-t) * p0 + t * p1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -55,6 +55,8 @@ Bug fixes
 
 * Convert ``center_of_mass`` and ``rotation_center`` to arrays in :class:`~capytaine.bodies.bodies.FloatingBody` constructor to avoid a few issues (:issue:`319` and :pull:`325`).
 
+* Fix bug (leading to either ``RuntimeError`` or wrong output) when clipping with plane that do not contain the origin. (:pull:`344`)
+
 Internals
 ~~~~~~~~~
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -55,7 +55,7 @@ Bug fixes
 
 * Convert ``center_of_mass`` and ``rotation_center`` to arrays in :class:`~capytaine.bodies.bodies.FloatingBody` constructor to avoid a few issues (:issue:`319` and :pull:`325`).
 
-* Fix bug (leading to either ``RuntimeError`` or wrong output) when clipping with plane that do not contain the origin. (:pull:`344`)
+* Fix bug (leading to either ``RuntimeError`` or wrong output) when clipping with plane that does not contain the origin. (:pull:`344`)
 
 Internals
 ~~~~~~~~~

--- a/pytest/test_meshes.py
+++ b/pytest/test_meshes.py
@@ -13,6 +13,7 @@ from capytaine.meshes.meshes import Mesh
 from capytaine.meshes.clipper import clip
 from capytaine.meshes.geometry import Plane, xOz_Plane
 from capytaine.bodies.predefined import HorizontalCylinder, Sphere, Rectangle
+from capytaine.meshes.predefined import mesh_rectangle
 
 # Some meshes that will be used in the following tests.
 test_mesh = Mesh(vertices=np.random.rand(4, 3), faces=[range(4)], name="test_mesh")
@@ -162,6 +163,20 @@ def test_clipper():
 
     mesh.keep_immersed_part(free_surface=0.0, sea_bottom=-1.0)
     assert np.allclose(mesh.merged().axis_aligned_bbox, aabb[:4] + (-1, 0,))  # the last item of the tuple has changed
+    
+    # Check boundaries after clipping
+    mesh = mesh_rectangle(size=(5,5), normal=(1,0,0))
+    assert max([i[2] for i in mesh.immersed_part(free_surface=-1).vertices])<=-1
+    assert max([i[2] for i in mesh.immersed_part(free_surface= 1).vertices])<= 1
+    assert min([i[2] for i in mesh.immersed_part(sea_bottom=-1).vertices])>=-1
+    assert min([i[2] for i in mesh.immersed_part(sea_bottom= 1).vertices])>= 1
+    
+    mesh = mesh_rectangle(size=(4,4), resolution=(1,1), normal=(1,0,0))
+    tmp = list(mesh.clip(Plane(normal=(0,0.1,1),point=(0,0,-1)),inplace=False).vertices)
+    tmp.sort(key=lambda x: x[2])
+    tmp.sort(key=lambda x: x[1])
+    assert np.allclose([i[2] for i in tmp], [-2, -0.8, -2, -1.2])
+    
 
 
 @pytest.mark.parametrize("size", [5, 6])

--- a/pytest/test_meshes.py
+++ b/pytest/test_meshes.py
@@ -168,8 +168,8 @@ def test_clipper():
     mesh = mesh_rectangle(size=(5,5), normal=(1,0,0))
     assert max([i[2] for i in mesh.immersed_part(free_surface=-1).vertices])<=-1
     assert max([i[2] for i in mesh.immersed_part(free_surface= 1).vertices])<= 1
-    assert min([i[2] for i in mesh.immersed_part(sea_bottom=-1).vertices])>=-1
-    assert min([i[2] for i in mesh.immersed_part(sea_bottom= 1).vertices])>= 1
+    assert min([i[2] for i in mesh.immersed_part(free_surface=np.infty, sea_bottom=-1).vertices])>=-1
+    assert min([i[2] for i in mesh.immersed_part(free_surface=np.infty, sea_bottom= 1).vertices])>= 1
     
     mesh = mesh_rectangle(size=(4,4), resolution=(1,1), normal=(1,0,0))
     tmp = list(mesh.clip(Plane(normal=(0,0.1,1),point=(0,0,-1)),inplace=False).vertices)


### PR DESCRIPTION
I might be misunderstanding how clipping is supposed to work, but currently
`amesh.immersed_part(free_surface=1) == amesh.immersed_part(free_surface=-1)`

I tracked it down to the `Plane.get_Edge_Intersection` method, where I think the `dot`product should be used to calculate the intermediate point, instead of the `norm`

```
import numpy as np
import capytaine as cpt

myMesh = cpt.meshes.Mesh
myClip = cpt.meshes.clipper.clip
myPlane = cpt.meshes.geometry.Plane

a = myMesh([[0,-2,-2],[0,2,-2],[0,2,2],[0,-2,2]],[[0,1,2,3]])

def getEdgeIntersection(P,p0,p1):
    p0n = np.dot(p0, P.normal)
    p1n = np.dot(p1, P.normal)
   ## use dot-product instead of norm ##
    c = np.dot(P.normal, P.point)
    t = (p0n - c) / (p0n - p1n)
    if t < 0. or t > 1.:
        raise RuntimeError('Intersection is outside the edge')
    return (1-t) * p0 + t * p1
    
def testit(P):
    b = myClip(a, P)
    c = P.get_edge_intersection(a.vertices[1], a.vertices[2])
    d = getEdgeIntersection(P, a.vertices[1], a.vertices[2])
    print(b.vertices)
    print(b.faces)
    print(c, " =?= ", d)

print("below 1")
testit(myPlane(point=[0,0,1]))
# expected [[0,-2,-2],[0,2,-2],[0,2,1],[0,-2,1]]
# ok

print("below -1")
testit(myPlane(point=[0,0,-1]))
# expected [[0,-2,-2],[0,2,-2],[0,2,-1],[0,-2,-1]]
# NOT OK : gives below 1

print("above 1")
testit(myPlane(normal=[0,0,-1],point=[0,0,1]))
# expected [[0,-2,1],[0,2,1],[0,2,2],[0,-2,2]]
# NOT OK : gives above -1

print("above -1")
testit(myPlane(normal=[0,0,-1],point=[0,0,-1]))
# expected [[0,-2,-1],[0,2,-1],[0,2,-2],[0,-2,-2]]
# ok

print("below slopeR 1")
testit(myPlane(normal=[0,0.1,1],point=[0,0,1]))
# expected [[0,-2,-2],[0,2,-2],[0,2,0.8],[0,-2,1.2]]
# OK

print("below slopeL 1")
testit(myPlane(normal=[0,-0.1,1],point=[0,0,1]))
# expected [[0,-2,-2],[0,2,-2],[0,2,1.2],[0,-2,0.8]]
# ok

print("below slopeR -1")
testit(myPlane(normal=[0,0.1,1],point=[0,0,-1]))
# expected [[0,-2,-2],[0,2,-2],[0,2,-1.2],[0,-2,-0.8]]
# NOT OK

print("below slopeL -1")
testit(myPlane(normal=[0,-0.1,1],point=[0,0,-1]))
# expected [[0,-2,-2],[0,2,-2],[0,2,-0.8],[0,-2,-1.2]]
# NOT OK
```