### PR TITLE
Accept FloatingBody and FreeSurface as list of points

### DIFF
--- a/capytaine/post_pro/free_surfaces.py
+++ b/capytaine/post_pro/free_surfaces.py
@@ -10,8 +10,6 @@ from itertools import product
 import numpy as np
 
 from capytaine.meshes.meshes import Mesh
-from capytaine.bem.problems_and_results import DiffractionProblem
-from capytaine.bem.airy_waves import airy_waves_potential
 
 LOG = logging.getLogger(__name__)
 
@@ -83,9 +81,10 @@ class FreeSurface():
         return (np.abs(self.x_range[1] - self.x_range[0])
                 * np.abs(self.y_range[1] - self.y_range[0]))
 
-    def incoming_waves(self, problem: DiffractionProblem) -> np.ndarray:
+    def incoming_waves(self, problem: "DiffractionProblem") -> np.ndarray:
+        from capytaine.bem.airy_waves import airy_waves_free_surface_elevation
         """Free surface elevation of the undisturbed incoming waves
         for a given diffraction problem.
+        Kept for legacy, but not recommended for use.
         """
-        return (1j * problem.omega / problem.g
-                * airy_waves_potential(self.mesh.faces_centers, problem))
+        return airy_waves_free_surface_elevation(self, problem)

--- a/capytaine/post_pro/free_surfaces.py
+++ b/capytaine/post_pro/free_surfaces.py
@@ -82,9 +82,9 @@ class FreeSurface():
                 * np.abs(self.y_range[1] - self.y_range[0]))
 
     def incoming_waves(self, problem: "DiffractionProblem") -> np.ndarray:
-        from capytaine.bem.airy_waves import airy_waves_free_surface_elevation
         """Free surface elevation of the undisturbed incoming waves
         for a given diffraction problem.
         Kept for legacy, but not recommended for use.
         """
+        from capytaine.bem.airy_waves import airy_waves_free_surface_elevation
         return airy_waves_free_surface_elevation(self, problem)

--- a/capytaine/tools/lists_of_points.py
+++ b/capytaine/tools/lists_of_points.py
@@ -1,8 +1,16 @@
 import numpy as np
+from capytaine.bodies import FloatingBody
+from capytaine.ui.vtk.free_surfaces import FreeSurface
 from capytaine.meshes import Mesh, CollectionOfMeshes
 
 
 def _normalize_points(points, keep_mesh=False):
+    if isinstance(points, (FloatingBody, FreeSurface)):
+        if keep_mesh:
+            return points.mesh, (points.mesh.nb_faces,)
+        else:
+            return points.mesh.faces_centers, (points.mesh.nb_faces,)
+
     if isinstance(points, (Mesh, CollectionOfMeshes)):
         if keep_mesh:
             return points, (points.nb_faces,)
@@ -25,7 +33,7 @@ def _normalize_points(points, keep_mesh=False):
         # points is now a (nx*ny*... , d) array
 
     else:
-        raise ValueError("This should not happen.")
+        raise ValueError(f"Expected a list of points or a mesh, but got instead: {points}")
 
     return points, output_shape
 

--- a/capytaine/tools/lists_of_points.py
+++ b/capytaine/tools/lists_of_points.py
@@ -1,6 +1,6 @@
 import numpy as np
 from capytaine.bodies import FloatingBody
-from capytaine.ui.vtk.free_surfaces import FreeSurface
+from capytaine.post_pro.free_surfaces import FreeSurface
 from capytaine.meshes import Mesh, CollectionOfMeshes
 
 
@@ -38,6 +38,9 @@ def _normalize_points(points, keep_mesh=False):
     return points, output_shape
 
 def _normalize_free_surface_points(points, keep_mesh=False):
+    if keep_mesh and isinstance(points, (FloatingBody, FreeSurface)):
+        return points.mesh, (points.mesh.nb_faces,)
+
     if keep_mesh and isinstance(points, (Mesh, CollectionOfMeshes)):
         return points, (points.nb_faces,)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,11 @@ Changelog
 New in next version
 -------------------
 
+Minor changes
+~~~~~~~~~~~~~
+
+* Support passing :class:`~capytaine.bodies.FloatingBody` or :class:`~capytaine.post_pro.free_surfaces.FreeSurface` objects to post-processing methods such as :meth:`~capytaine.bem.solver.BEMSolver.compute_potential` and :meth:`~capytaine.bem.solver.BEMSolver.compute_free_surface_elevation`. (:pull:`379`)
+
 Bug fixes
 ~~~~~~~~~
 

--- a/docs/user_manual/examples/animate_free_surface.py
+++ b/docs/user_manual/examples/animate_free_surface.py
@@ -28,11 +28,11 @@ radiation_result = solver.solve(radiation_problem)
 
 # Define a mesh of the free surface and compute the free surface elevation
 free_surface = cpt.FreeSurface(x_range=(-50, 50), y_range=(-50, 50), nx=150, ny=150)
-diffraction_elevation_at_faces = solver.compute_free_surface_elevation(free_surface.mesh, diffraction_result)
-radiation_elevation_at_faces = solver.compute_free_surface_elevation(free_surface.mesh, radiation_result)
+diffraction_elevation_at_faces = solver.compute_free_surface_elevation(free_surface, diffraction_result)
+radiation_elevation_at_faces = solver.compute_free_surface_elevation(free_surface, radiation_result)
 
 # Add incoming waves
-diffraction_elevation_at_faces = diffraction_elevation_at_faces + airy_waves_free_surface_elevation(free_surface.mesh, diffraction_problem)
+diffraction_elevation_at_faces = diffraction_elevation_at_faces + airy_waves_free_surface_elevation(free_surface, diffraction_problem)
 
 # Run the animations
 animation = Animation(loop_duration=diffraction_result.period)

--- a/docs/user_manual/examples/boat_animation.py
+++ b/docs/user_manual/examples/boat_animation.py
@@ -37,11 +37,11 @@ def setup_animation(body, fs, omega, wave_amplitude, wave_direction):
 
     # COMPUTE FREE SURFACE ELEVATION
     # Compute the diffracted wave pattern
-    incoming_waves_elevation = airy_waves_free_surface_elevation(fs.mesh, diffraction_result)
-    diffraction_elevation = bem_solver.compute_free_surface_elevation(fs.mesh, diffraction_result)
+    incoming_waves_elevation = airy_waves_free_surface_elevation(fs, diffraction_result)
+    diffraction_elevation = bem_solver.compute_free_surface_elevation(fs, diffraction_result)
 
     # Compute the wave pattern radiated by the RAO
-    radiation_elevations_per_dof = {res.radiating_dof: bem_solver.compute_free_surface_elevation(fs.mesh, diffraction_result) for res in radiation_results}
+    radiation_elevations_per_dof = {res.radiating_dof: bem_solver.compute_free_surface_elevation(fs, diffraction_result) for res in radiation_results}
     radiation_elevation = sum(rao.sel(omega=omega, radiating_dof=dof).data * radiation_elevations_per_dof[dof] for dof in body.dofs)
 
     # SET UP ANIMATION

--- a/docs/user_manual/post_pro.rst
+++ b/docs/user_manual/post_pro.rst
@@ -47,6 +47,15 @@ The point(s) can be given in several ways:
 
     solver.compute_potential(mesh, results)
 
+- or a floating body, in which case the corresponding mesh will be used::
+
+    solver.compute_potential(body, results)
+
+- or a :class:`~capytaine.post_pro.free_surfaces.FreeSurface` object, although the use of this object is not recommended unless you are preparing a 3D animation with the Capytaine's VTK viewer which still require this object at the moment::
+
+    fs = cpt.FreeSurface(x_range=(-10, 10), y_range=(-10, 10))
+    solver.compute_potential(fs, results)
+
 The returned values is an array of shape matching the shape of the input points.
 
 .. warning::

--- a/pytest/test_bem_potential_velocity_and_free_surface_elevation.py
+++ b/pytest/test_bem_potential_velocity_and_free_surface_elevation.py
@@ -199,6 +199,22 @@ def test_compute_free_surface_elevation_on_mesh(solver, result):
     assert fse.shape == (mesh.nb_faces,)
 
 
+#################
+#  FreeSurface  #
+#################
+
+def test_airy_waves_free_surface_elevation_on_free_surface(result):
+    from capytaine.bem.airy_waves import airy_waves_free_surface_elevation
+    fs = cpt.FreeSurface(nx=3, ny=3)
+    fse = airy_waves_free_surface_elevation(fs, result)
+    assert fse.shape == (fs.mesh.nb_faces,)
+
+def test_compute_free_surface_elevation_on_free_surface(solver, result):
+    fs = cpt.FreeSurface(nx=3, ny=3)
+    fse = solver.compute_free_surface_elevation(fs, result)
+    assert fse.shape == (fs.mesh.nb_faces,)
+
+
 #######################################################################
 #                            Check values                             #
 #######################################################################


### PR DESCRIPTION
When calling `solver.compute_free_surface_elevation()` and other similar methods, one can now pass `FloatingBody` or a `FreeSurface` object directly.
The latter are still required to work with vtk `Animation`.