### PR TITLE
Fix BEMIO import

### DIFF
--- a/capytaine/io/bemio.py
+++ b/capytaine/io/bemio.py
@@ -31,7 +31,6 @@ def dataframe_from_bemio(bemio_obj, wavenumber, wavelength):
 
 
     dofs = np.array(['Surge', 'Sway', 'Heave', 'Roll', 'Pitch', 'Yaw'])
-    df = pd.DataFrame()
     for i in range(bemio_obj.body[0].num_bodies):
         difr_dict = []
         rad_dict = []
@@ -53,6 +52,7 @@ def dataframe_from_bemio(bemio_obj, wavenumber, wavelength):
                 temp_dict['body_name'] = bemio_obj.body[i].name
                 temp_dict['water_depth'] = bemio_obj.body[i].water_depth
                 temp_dict['omega'] = omega
+                temp_dict['period'] = 2*np.pi/omega
                 temp_dict['rho'] = rho
                 temp_dict['g'] = g
                 temp_dict['wave_direction'] = np.radians(dir)
@@ -133,8 +133,10 @@ def dataframe_from_bemio(bemio_obj, wavenumber, wavelength):
 
                 rad_dict.append(temp_dict)
 
-    df = df.append(pd.DataFrame.from_dict(difr_dict).explode(['influenced_dof', 'diffraction_force', 'Froude_Krylov_force']))
-    df = df.append(pd.DataFrame.from_dict(rad_dict).explode(['influenced_dof', 'added_mass', 'radiation_damping']))
+    df = pd.concat([
+        pd.DataFrame.from_dict(difr_dict).explode(['influenced_dof', 'diffraction_force', 'Froude_Krylov_force']),
+        pd.DataFrame.from_dict(rad_dict).explode(['influenced_dof', 'added_mass', 'radiation_damping'])
+        ])
     df = df.astype({'added_mass': np.float64, 'radiation_damping': np.float64, 'diffraction_force': np.complex128, 'Froude_Krylov_force': np.complex128})
 
     return df

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,7 +18,7 @@ Bug fixes
 
 * Fix the single precision Green function (:code:`cpt.Delhommeau(floating_point_precision="float32")`) that was broken in v2.0. (:issue:`377` and :pull:`378`)
 
-* Update the BEMIO import feature to work with Pandas 2.0 and output periods as now done in Capytaine 2.0. A version of BEMIO that works in recent version of Python and Numpy can be found at https://github.com/mancellin/bemio. (:pull:`381`)
+* Update the BEMIO import feature to work with Pandas 2.0 and output periods as now done in Capytaine 2.0. A version of BEMIO that works in recent version of Python and Numpy can be found at `https://github.com/mancellin/bemio`_. (:pull:`381`)
 
 -------------------------------
 New in version 2.0 (2023-06-21)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,8 @@ Bug fixes
 
 * Fix the single precision Green function (:code:`cpt.Delhommeau(floating_point_precision="float32")`) that was broken in v2.0. (:issue:`377` and :pull:`378`)
 
+* Update the BEMIO import feature to work with Pandas 2.0 and output periods as now done in Capytaine 2.0. A version of BEMIO that works in recent version of Python and Numpy can be found at https://github.com/mancellin/bemio. (:pull:`381`)
+
 -------------------------------
 New in version 2.0 (2023-06-21)
 -------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ['version']
 ci = [
     "pytest",
     "hypothesis",
-    "bemio @ https://github.com/mancellin/archive/fa3a6d3d4b0862491c3723919ec8ee45cc7d055.zip",
+    "bemio @ https://github.com/mancellin/bemio/archive/fa3a6d3d4b0862491c3723919ec8ee45cc7d055a.zip",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,11 @@ scripts = {capytaine = "capytaine.ui.cli:main"}
 dynamic = ['version']
 
 [project.optional-dependencies]
-ci = ["pytest", "hypothesis"]
+ci = [
+    "pytest",
+    "hypothesis",
+    "bemio @ https://github.com/mancellin/archive/fa3a6d3d4b0862491c3723919ec8ee45cc7d055.zip",
+]
 
 [build-system]
 build-backend = 'mesonpy'


### PR DESCRIPTION
- Deprecation of df.append in Pandas 2.0
- Outputing periods in dataset since Capytaine 2.0
- Also, BEMIO needs some updates to work with Python 3.11 and Numpy 1.25, as done in https://github.com/mancellin/bemio