### PR TITLE
Improve string representation of Capytaine objects

### DIFF
--- a/capytaine/bem/problems_and_results.py
+++ b/capytaine/bem/problems_and_results.py
@@ -200,7 +200,7 @@ class LinearPotentialFlowProblem:
 
     def __str__(self):
         """Do not display default values in str(problem)."""
-        parameters = [f"body={self.body.__short_str__()}",
+        parameters = [f"body={self.body.__short_str__() if self.body is not None else None}",
                       f"{self.provided_freq_type}={self.__getattribute__(self.provided_freq_type):.3f}",
                       f"water_depth={self.water_depth}"]
         try:
@@ -224,7 +224,7 @@ class LinearPotentialFlowProblem:
         p.text(self.__str__())
 
     def __rich_repr__(self):
-        yield "body", self.body
+        yield "body", self.body, None
         yield self.provided_freq_type, self.__getattribute__(self.provided_freq_type)
         yield "water_depth", self.water_depth, _default_parameters["water_depth"]
         try:
@@ -406,6 +406,7 @@ class LinearPotentialFlowResult:
     __str__ = LinearPotentialFlowProblem.__str__
     __repr__ = LinearPotentialFlowProblem.__repr__
     _repr_pretty_ = LinearPotentialFlowProblem._repr_pretty_
+    __rich_repr__ = LinearPotentialFlowProblem.__rich_repr__
 
 
 class DiffractionResult(LinearPotentialFlowResult):
@@ -414,6 +415,9 @@ class DiffractionResult(LinearPotentialFlowResult):
         self.forces = {}
         super().__init__(problem, *args, **kwargs)
         self.wave_direction = self.problem.wave_direction
+
+    _str_other_attributes = DiffractionProblem._str_other_attributes
+    _specific_rich_repr = DiffractionProblem._specific_rich_repr
 
     def store_force(self, dof, force):
         self.forces[dof] = force
@@ -436,6 +440,9 @@ class RadiationResult(LinearPotentialFlowResult):
         self.radiation_dampings = {}
         super().__init__(problem, *args, **kwargs)
         self.radiating_dof = self.problem.radiating_dof
+
+    _str_other_attributes = RadiationProblem._str_other_attributes
+    _specific_rich_repr = RadiationProblem._specific_rich_repr
 
     def store_force(self, dof, force):
         self.added_masses[dof] = force.real/self.omega**2

--- a/capytaine/bem/problems_and_results.py
+++ b/capytaine/bem/problems_and_results.py
@@ -200,7 +200,7 @@ class LinearPotentialFlowProblem:
 
     def __str__(self):
         """Do not display default values in str(problem)."""
-        parameters = [f"body={self.body_name}",
+        parameters = [f"body={self.body.__short_str__()}",
                       f"{self.provided_freq_type}={self.__getattribute__(self.provided_freq_type):.3f}",
                       f"water_depth={self.water_depth}"]
         try:
@@ -222,6 +222,17 @@ class LinearPotentialFlowProblem:
 
     def _repr_pretty_(self, p, cycle):
         p.text(self.__str__())
+
+    def __rich_repr__(self):
+        yield "body", self.body
+        yield self.provided_freq_type, self.__getattribute__(self.provided_freq_type)
+        yield "water_depth", self.water_depth, _default_parameters["water_depth"]
+        try:
+            yield from self._specific_rich_repr()
+        except:
+            pass
+        yield "g", self.g, _default_parameters["g"]
+        yield "rho", self.rho, _default_parameters["rho"]
 
     def _astuple(self):
         return (self.body, self.free_surface, self.water_depth,
@@ -300,6 +311,9 @@ class DiffractionProblem(LinearPotentialFlowProblem):
     def _str_other_attributes(self):
         return [f"wave_direction={self.wave_direction:.3f}"]
 
+    def _specific_rich_repr(self):
+        yield "wave_direction", self.wave_direction, _default_parameters["wave_direction"]
+
     def make_results_container(self, *args, **kwargs):
         return DiffractionResult(self, *args, **kwargs)
 
@@ -348,6 +362,9 @@ class RadiationProblem(LinearPotentialFlowProblem):
 
     def _str_other_attributes(self):
         return [f"radiating_dof=\'{self.radiating_dof}\'"]
+
+    def _specific_rich_repr(self):
+        yield "radiating_dof", self.radiating_dof
 
     def make_results_container(self, *args, **kwargs):
         return RadiationResult(self, *args, **kwargs)

--- a/capytaine/bodies/bodies.py
+++ b/capytaine/bodies/bodies.py
@@ -966,15 +966,37 @@ respective inertia coefficients are assigned as NaN.")
     #  Display  #
     #############
 
+    def __short_str__(self):
+        return (f"{self.__class__.__name__}(..., name=\"{self.name}\")")
+
+    def _optional_params_str(self):
+        items = []
+        if self.mass is not None: items.append(f"mass={self.mass}, ")
+        if self.center_of_mass is not None: items.append(f"center_of_mass={self.center_of_mass}, ")
+        return ''.join(items)
+
     def __str__(self):
-        return self.name
+        short_dofs = '{' + ', '.join('"{}": ...'.format(d) for d in self.dofs) + '}'
+        return (f"{self.__class__.__name__}(mesh={self.mesh.__short_str__()}, dofs={short_dofs}, {self._optional_params_str()}name=\"{self.name}\")")
 
     def __repr__(self):
-        return (f"{self.__class__.__name__}(mesh={self.mesh.name}, "
-                f"dofs={{{', '.join(self.dofs.keys())}}}, name={self.name})")
+        short_dofs = '{' + ', '.join('"{}": ...'.format(d) for d in self.dofs) + '}'
+        return (f"{self.__class__.__name__}(mesh={str(self.mesh)}, dofs={short_dofs}, {self._optional_params_str()}name=\"{self.name}\")")
 
     def _repr_pretty_(self, p, cycle):
-        p.text(self.__repr__())
+        p.text(self.__str__())
+
+    def __rich_repr__(self):
+        class DofWithShortRepr:
+            def __repr__(self):
+                return '...'
+        yield "mesh", self.mesh
+        yield "dofs", {d: DofWithShortRepr() for d in self.dofs}
+        if self.mass is not None:
+            yield "mass", self.mass, None
+        if self.center_of_mass is not None:
+            yield "center_of_mass", tuple(self.center_of_mass)
+        yield "name", self.name
 
     def show(self, **kwargs):
         from capytaine.ui.vtk.body_viewer import FloatingBodyViewer

--- a/capytaine/meshes/collections.py
+++ b/capytaine/meshes/collections.py
@@ -46,24 +46,25 @@ class CollectionOfMeshes(ClippableMixin, SurfaceIntegralsMixin, Abstract3DObject
 
         LOG.debug(f"New collection of meshes: {repr(self)}")
 
-    def __repr__(self):
-        reprer = reprlib.Repr()
-        reprer.maxstring = 100
-        reprer.maxother = 100
-        meshes_names = reprer.repr(self._meshes)
-        if self.name is not None:
-            return f"{self.__class__.__name__}({meshes_names}, name={self.name})"
-        else:
-            return f"{self.__class__.__name__}{meshes_names}"
-
-    def _repr_pretty_(self, p, cycle):
-        p.text(self.__repr__())
+    def __short_str__(self):
+        return (f"{self.__class__.__name__}(..., name=\"{self.name}\")")
 
     def __str__(self):
-        if self.name is not None:
-            return self.name
+        if len(self._meshes) < 3:
+            meshes_str = ', '.join(m.__short_str__() for m in self._meshes)
         else:
-            return repr(self)
+            meshes_str = self._meshes[0].__short_str__() + ", ..., " + self._meshes[-1].__short_str__()
+        return f"{self.__class__.__name__}([{meshes_str}], name=\"{self.name}\")"
+
+    def __repr__(self):
+        reprer = reprlib.Repr()
+        reprer.maxstring = 200
+        reprer.maxother = 200
+        meshes_names = reprer.repr(self._meshes)
+        return f"{self.__class__.__name__}({meshes_names}, name=\"{self.name}\")"
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(self.__str__())
 
     def __iter__(self):
         return iter(self._meshes)
@@ -95,7 +96,7 @@ class CollectionOfMeshes(ClippableMixin, SurfaceIntegralsMixin, Abstract3DObject
                 shift  = ' │ '
             body_tree_views.append(prefix + tree_view.replace('\n', '\n' + shift))
 
-        return self.name + '\n' + '\n'.join(body_tree_views)
+        return self.__short_str__() + '\n' + '\n'.join(body_tree_views)
 
     def copy(self, name=None):
         from copy import deepcopy

--- a/capytaine/meshes/collections.py
+++ b/capytaine/meshes/collections.py
@@ -57,14 +57,20 @@ class CollectionOfMeshes(ClippableMixin, SurfaceIntegralsMixin, Abstract3DObject
         return f"{self.__class__.__name__}([{meshes_str}], name=\"{self.name}\")"
 
     def __repr__(self):
-        reprer = reprlib.Repr()
-        reprer.maxstring = 200
-        reprer.maxother = 200
-        meshes_names = reprer.repr(self._meshes)
-        return f"{self.__class__.__name__}({meshes_names}, name=\"{self.name}\")"
+        return f"{self.__class__.__name__}({', '.join(str(m) for m in self._meshes)}, name=\"{self.name}\")"
 
     def _repr_pretty_(self, p, cycle):
         p.text(self.__str__())
+
+    def __rich_repr__(self):
+        class WrappedString:
+            def __init__(self, s):
+                self.s = s
+            def __repr__(self):
+                return self.s
+        for m in self._meshes:
+            yield m
+        yield "name", self.name
 
     def __iter__(self):
         return iter(self._meshes)

--- a/capytaine/meshes/collections.py
+++ b/capytaine/meshes/collections.py
@@ -39,7 +39,10 @@ class CollectionOfMeshes(ClippableMixin, SurfaceIntegralsMixin, Abstract3DObject
         for mesh in self._meshes:
             assert isinstance(mesh, Mesh) or isinstance(mesh, CollectionOfMeshes)
 
-        self.name = name
+        if name is None:
+            self.name = f'collection_of_meshes_{next(Mesh._ids)}'
+        else:
+            self.name = str(name)
 
         LOG.debug(f"New collection of meshes: {repr(self)}")
 

--- a/capytaine/meshes/meshes.py
+++ b/capytaine/meshes/meshes.py
@@ -67,13 +67,26 @@ class Mesh(ClippableMixin, SurfaceIntegralsMixin, Abstract3DObject):
                 f"faces=[[... {self.nb_faces} faces ...]], name=\"{self.name}\")")
 
     def __repr__(self):
-        shift = len(self.__class__.__name__) + 1
-        vert_str = np.array_repr(self.vertices).replace('\n', '\n' + (shift + 9)*' ')
-        faces_str = np.array_repr(self.faces).replace('\n', '\n' + (shift + 6)*' ')
-        return f"{self.__class__.__name__}(\n{' '*shift}vertices={vert_str},\n{' '*shift}faces={faces_str}\n{' '*shift}name=\"{self.name}\",\n)"
+        # shift = len(self.__class__.__name__) + 1
+        # vert_str = np.array_repr(self.vertices).replace('\n', '\n' + (shift + 9)*' ')
+        # faces_str = np.array_repr(self.faces).replace('\n', '\n' + (shift + 6)*' ')
+        # return f"{self.__class__.__name__}(\n{' '*shift}vertices={vert_str},\n{' '*shift}faces={faces_str}\n{' '*shift}name=\"{self.name}\"\n)"
+        return (f"{self.__class__.__name__}(vertices=[[... {self.nb_vertices} vertices ...]], "
+                f"faces=[[... {self.nb_faces} faces ...]], name=\"{self.name}\")")
 
     def _repr_pretty_(self, p, cycle):
         p.text(self.__str__())
+
+    def __rich_repr__(self):
+        class CustomRepr:
+            def __init__(self, n, kind):
+                self.n = n
+                self.kind = kind
+            def __repr__(self):
+                return "[[... {} {} ...]]".format(self.n, self.kind)
+        yield "vertices", CustomRepr(self.nb_vertices, "vertices")
+        yield "faces", CustomRepr(self.nb_faces, "faces")
+        yield "name", self.name
 
     @property
     def nb_vertices(self) -> int:

--- a/capytaine/meshes/meshes.py
+++ b/capytaine/meshes/meshes.py
@@ -59,15 +59,21 @@ class Mesh(ClippableMixin, SurfaceIntegralsMixin, Abstract3DObject):
 
         LOG.debug(f"New mesh: {repr(self)}")
 
+    def __short_str__(self):
+        return (f"{self.__class__.__name__}(..., name=\"{self.name}\")")
+
     def __str__(self):
-        return self.name
+        return (f"{self.__class__.__name__}(vertices=[[... {self.nb_vertices} vertices ...]], "
+                f"faces=[[... {self.nb_faces} faces ...]], name=\"{self.name}\")")
 
     def __repr__(self):
-        return (f"{self.__class__.__name__}(nb_vertices={self.nb_vertices}, "
-                f"nb_faces={self.nb_faces}, name={self.name})")
+        shift = len(self.__class__.__name__) + 1
+        vert_str = np.array_repr(self.vertices).replace('\n', '\n' + (shift + 9)*' ')
+        faces_str = np.array_repr(self.faces).replace('\n', '\n' + (shift + 6)*' ')
+        return f"{self.__class__.__name__}(\n{' '*shift}vertices={vert_str},\n{' '*shift}faces={faces_str}\n{' '*shift}name=\"{self.name}\",\n)"
 
     def _repr_pretty_(self, p, cycle):
-        p.text(self.__repr__())
+        p.text(self.__str__())
 
     @property
     def nb_vertices(self) -> int:
@@ -133,7 +139,7 @@ class Mesh(ClippableMixin, SurfaceIntegralsMixin, Abstract3DObject):
 
     def tree_view(self, **kwargs):
         """Dummy method to be generalized for collections of meshes."""
-        return self.name
+        return self.__short_str__()
 
     def to_meshmagick(self):
         """Convert the Mesh object as a Mesh object from meshmagick.

--- a/capytaine/meshes/symmetric.py
+++ b/capytaine/meshes/symmetric.py
@@ -62,14 +62,15 @@ class ReflectionSymmetricMesh(SymmetricMesh):
             LOG.debug(f"New mirror symmetric mesh.")
 
     def __str__(self):
-        return f"{self.__class__.__name__}({self.half}, plane={self.plane}, name=\"{self.name}\")"
+        return f"{self.__class__.__name__}({self.half.__short_str__()}, plane={self.plane}, name=\"{self.name}\")"
 
     def __repr__(self):
-        reprer = reprlib.Repr()
-        reprer.maxstring = 200
-        reprer.maxother = 200
-        meshes_names = reprer.repr(self.half)
-        return f"{self.__class__.__name__}({meshes_names}, plane={self.plane}, name=\"{self.name}\")"
+        return f"{self.__class__.__name__}({self.half}, plane={self.plane}, name=\"{self.name}\")"
+
+    def __rich_repr__(self):
+        yield self.half
+        yield "plane", self.plane
+        yield "name", self.name
 
     @property
     def half(self):
@@ -157,14 +158,16 @@ class TranslationalSymmetricMesh(SymmetricMesh):
         return self[0]
 
     def __str__(self):
-        return f"{self.__class__.__name__}({self.first_slice}, translation={self.translation}, nb_repetitions={len(self)-1}, name=\"{self.name}\")"
+        return f"{self.__class__.__name__}({self.first_slice.__short_str__()}, translation={self.translation}, nb_repetitions={len(self)-1}, name=\"{self.name}\")"
 
     def __repr__(self):
-        reprer = reprlib.Repr()
-        reprer.maxstring = 200
-        reprer.maxother = 200
-        meshes_names = reprer.repr(self.first_slice)
         return f"{self.__class__.__name__}({self.first_slice}, translation={self.translation}, nb_repetitions={len(self)-1}, name=\"{self.name}\")"
+
+    def __rich_repr__(self):
+        yield self.first_slice
+        yield "translation", self.translation
+        yield "nb_repetitions", len(self)-1
+        yield "name", self.name
 
     def tree_view(self, fold_symmetry=True, **kwargs):
         if fold_symmetry:
@@ -332,14 +335,16 @@ class AxialSymmetricMesh(SymmetricMesh):
         return self[0]
 
     def __str__(self):
-        return f"{self.__class__.__name__}({self.first_slice}, axis={self.axis}, nb_repetitions={len(self)-1}, name=\"{self.name}\")"
+        return f"{self.__class__.__name__}({self.first_slice.__short_str__()}, axis={self.axis}, nb_repetitions={len(self)-1}, name=\"{self.name}\")"
 
     def __repr__(self):
-        reprer = reprlib.Repr()
-        reprer.maxstring = 200
-        reprer.maxother = 200
-        meshes_names = reprer.repr(self.first_slice)
         return f"{self.__class__.__name__}({self.first_slice}, axis={self.axis}, nb_repetitions={len(self)-1}, name=\"{self.name}\")"
+
+    def __rich_repr__(self):
+        yield self.first_slice
+        yield "axis", self.axis
+        yield "nb_repetitions", len(self)-1
+        yield "name", self.name
 
     def tree_view(self, fold_symmetry=True, **kwargs):
         if fold_symmetry:

--- a/capytaine/meshes/symmetric.py
+++ b/capytaine/meshes/symmetric.py
@@ -49,6 +49,9 @@ class ReflectionSymmetricMesh(SymmetricMesh):
 
         other_half = half.mirrored(plane, name=f"mirrored_of_{str(half)}")
 
+        if name is None:
+            name = f"reflection_of_{half.name}"
+
         super().__init__((half, other_half), name=name)
 
         self.plane = plane.copy()
@@ -126,6 +129,9 @@ class TranslationalSymmetricMesh(SymmetricMesh):
         slices = [mesh_slice]
         for i in range(1, nb_repetitions+1):
             slices.append(mesh_slice.translated(vector=i*translation, name=f"repetition_{i}_of_{mesh_slice.name}"))
+
+        if name is None:
+            name = f"translation_of_{mesh_slice.name}"
 
         super().__init__(slices, name=name)
 
@@ -231,6 +237,9 @@ class AxialSymmetricMesh(SymmetricMesh):
         for i in range(1, nb_repetitions+1):
             slices.append(mesh_slice.rotated(axis, angle=2*i*np.pi/(nb_repetitions+1),
                                              name=f"rotation_{i}_of_{mesh_slice.name}"))
+
+        if name is None:
+            name = f"rotation_of_{mesh_slice.name}"
 
         super().__init__(slices, name=name)
 

--- a/capytaine/meshes/symmetric.py
+++ b/capytaine/meshes/symmetric.py
@@ -47,19 +47,29 @@ class ReflectionSymmetricMesh(SymmetricMesh):
         assert isinstance(plane, Plane)
         assert plane.normal[2] == 0, "Only vertical reflection planes are supported in ReflectionSymmetry classes."
 
-        other_half = half.mirrored(plane, name=f"mirrored_of_{str(half)}")
+        other_half = half.mirrored(plane, name=f"mirrored_of_{half.name}")
 
         if name is None:
             name = f"reflection_of_{half.name}"
 
-        super().__init__((half, other_half), name=name)
-
         self.plane = plane.copy()
+
+        super().__init__((half, other_half), name=name)
 
         if self.name is not None:
             LOG.debug(f"New mirror symmetric mesh: {self.name}.")
         else:
             LOG.debug(f"New mirror symmetric mesh.")
+
+    def __str__(self):
+        return f"{self.__class__.__name__}({self.half}, plane={self.plane}, name=\"{self.name}\")"
+
+    def __repr__(self):
+        reprer = reprlib.Repr()
+        reprer.maxstring = 200
+        reprer.maxother = 200
+        meshes_names = reprer.repr(self.half)
+        return f"{self.__class__.__name__}({meshes_names}, plane={self.plane}, name=\"{self.name}\")"
 
     @property
     def half(self):
@@ -67,8 +77,8 @@ class ReflectionSymmetricMesh(SymmetricMesh):
 
     def tree_view(self, fold_symmetry=True, **kwargs):
         if fold_symmetry:
-            return (str(self) + '\n' + ' ├─' + self.half.tree_view().replace('\n', '\n │ ') + '\n'
-                    + f" └─mirrored copy of the above {str(self.half)}")
+            return (self.__short_str__() + '\n' + ' ├─' + self.half.tree_view().replace('\n', '\n │ ') + '\n'
+                    + f" └─mirrored copy of the above {self.half.__short_str__()}")
         else:
             return CollectionOfMeshes.tree_view(self, **kwargs)
 
@@ -133,9 +143,9 @@ class TranslationalSymmetricMesh(SymmetricMesh):
         if name is None:
             name = f"translation_of_{mesh_slice.name}"
 
-        super().__init__(slices, name=name)
-
         self.translation = translation
+
+        super().__init__(slices, name=name)
 
         if self.name is not None:
             LOG.debug(f"New translation symmetric mesh: {self.name}.")
@@ -146,10 +156,20 @@ class TranslationalSymmetricMesh(SymmetricMesh):
     def first_slice(self):
         return self[0]
 
+    def __str__(self):
+        return f"{self.__class__.__name__}({self.first_slice}, translation={self.translation}, nb_repetitions={len(self)-1}, name=\"{self.name}\")"
+
+    def __repr__(self):
+        reprer = reprlib.Repr()
+        reprer.maxstring = 200
+        reprer.maxother = 200
+        meshes_names = reprer.repr(self.first_slice)
+        return f"{self.__class__.__name__}({self.first_slice}, translation={self.translation}, nb_repetitions={len(self)-1}, name=\"{self.name}\")"
+
     def tree_view(self, fold_symmetry=True, **kwargs):
         if fold_symmetry:
-            return (str(self) + '\n' + ' ├─' + self.first_slice.tree_view().replace('\n', '\n │ ') + '\n'
-                    + f" └─{len(self)-1} translated copies of the above {str(self.first_slice)}")
+            return (self.__short_str__() + '\n' + ' ├─' + self.first_slice.tree_view().replace('\n', '\n │ ') + '\n'
+                    + f" └─{len(self)-1} translated copies of the above {self.first_slice.__short_str__()}")
         else:
             return CollectionOfMeshes.tree_view(self, **kwargs)
 
@@ -241,12 +261,12 @@ class AxialSymmetricMesh(SymmetricMesh):
         if name is None:
             name = f"rotation_of_{mesh_slice.name}"
 
+        self.axis = axis.copy()
+
         super().__init__(slices, name=name)
 
         if not axis.is_parallel_to(Oz_axis):
             LOG.warning(f"{self.name} is an axi-symmetric mesh along a non vertical axis.")
-
-        self.axis = axis.copy()
 
         if self.name is not None:
             LOG.debug(f"New rotation symmetric mesh: {self.name}.")
@@ -311,10 +331,20 @@ class AxialSymmetricMesh(SymmetricMesh):
     def first_slice(self):
         return self[0]
 
+    def __str__(self):
+        return f"{self.__class__.__name__}({self.first_slice}, axis={self.axis}, nb_repetitions={len(self)-1}, name=\"{self.name}\")"
+
+    def __repr__(self):
+        reprer = reprlib.Repr()
+        reprer.maxstring = 200
+        reprer.maxother = 200
+        meshes_names = reprer.repr(self.first_slice)
+        return f"{self.__class__.__name__}({self.first_slice}, axis={self.axis}, nb_repetitions={len(self)-1}, name=\"{self.name}\")"
+
     def tree_view(self, fold_symmetry=True, **kwargs):
         if fold_symmetry:
-            return (str(self) + '\n' + ' ├─' + self.first_slice.tree_view().replace('\n', '\n │ ') + '\n'
-                    + f" └─{len(self)-1} rotated copies of the above {str(self.first_slice)}")
+            return (self.__short_str__() + '\n' + ' ├─' + self.first_slice.tree_view().replace('\n', '\n │ ') + '\n'
+                    + f" └─{len(self)-1} rotated copies of the above {self.first_slice.__short_str__()}")
         else:
             return CollectionOfMeshes.tree_view(self, **kwargs)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,8 @@ Minor changes
 
 * Add `top_light_intensity` optional arguments to :meth:`~capytaine.ui.vtk.animations.Animation.run` and :meth:`~capytaine.ui.vtk.animations.Animation.save` to illuminate the scene from top. (:pull:`380`)
 
+* Clean up ``__str__`` and ``__repr__`` representation of many objects. Also `rich.print` now return even nicer representations. (:pull:`384`)
+
 Bug fixes
 ~~~~~~~~~
 

--- a/pytest/test_bodies.py
+++ b/pytest/test_bodies.py
@@ -90,7 +90,6 @@ def test_healing_before_initializing_dofs():
 
 def test_bodies():
     body = Sphere(name="sphere", axial_symmetry=False)
-    assert str(body) == "sphere"
     repr(body)
     assert np.allclose(body.geometric_center, (0, 0, 0))
     body.add_translation_dof(name="Surge")

--- a/pytest/test_meshes.py
+++ b/pytest/test_meshes.py
@@ -53,10 +53,6 @@ def test_vertices_and_faces_get_and_set():
 
 def test_mesh_naming():
     """Test how the mesh handle names and string representation."""
-    # Test string representation
-    assert str(test_mesh) == 'test_mesh'  # Just the name
-    assert repr(test_mesh) == "Mesh(nb_vertices=4, nb_faces=1, name=test_mesh)"  # A longer representation.
-
     # Test automatic naming
     dummy_mesh = Mesh()  # Automatically named something like mesh_1
     other_dummy_mesh = Mesh()  # Automatically named something like mesh_2

--- a/pytest/test_meshes_collections_and_symmetries.py
+++ b/pytest/test_meshes_collections_and_symmetries.py
@@ -60,17 +60,7 @@ def test_collection():
     other_sphere = Sphere(name="bar", center=(0, 0, 2)).mesh
 
     coll = CollectionOfMeshes([sphere, other_sphere], name="baz")
-    assert str(coll) == "baz"
-    assert repr(coll) == ("CollectionOfMeshes("
-                          "(AxialSymmetricMesh(Mesh(nb_vertices=20, nb_faces=10, name=slice_of_foo_mesh), name=foo_mesh), "
-                          "AxialSymmetricMesh(Mesh(nb_vertices=20, nb_faces=10, name=slice_of_bar_mesh), name=bar_mesh)), "
-                          "name=baz)")
-
     coll2 = CollectionOfMeshes([sphere, other_sphere])
-    assert repr(coll2) == ("CollectionOfMeshes("
-                           "AxialSymmetricMesh(Mesh(nb_vertices=20, nb_faces=10, name=slice_of_foo_mesh), name=foo_mesh), "
-                           "AxialSymmetricMesh(Mesh(nb_vertices=20, nb_faces=10, name=slice_of_bar_mesh), name=bar_mesh))")
-    assert str(coll2) == repr(coll2)
 
     assert coll == coll2
     assert hash(coll) == hash(coll2)


### PR DESCRIPTION
The `__str__` and `__repr__` (that is what you get when you `print()`) of many object such as meshes or floating bodies was kinda broken (string without quotes, etc...). This fixes most of it and add support for nice printing with `rich`.

Code sample to test that:
```python
import capytaine as cpt
import rich
from rich.panel import Panel
from rich.pretty import Pretty
from rich.console import Group
import logging

logging.basicConfig(level=logging.ERROR)

def show(o):
    rich.print(Panel(Group(str(o), "", repr(o), "", Pretty(o)), title=o.__class__.__name__))

mesh = cpt.mesh_sphere()
show(mesh)
show(cpt.CollectionOfMeshes([mesh, mesh.copy(), mesh.copy()]))
show(cpt.ReflectionSymmetricMesh(mesh, cpt.xOz_Plane))
show(cpt.TranslationalSymmetricMesh(mesh, [1.0, 0.0, 0.0], 5))
show(cpt.AxialSymmetricMesh(mesh, cpt.Axis(vector=[0, 0, 1]), 5))
bd = cpt.FloatingBody(mesh, dofs=cpt.rigid_body_dofs())
show(bd)
show(cpt.DiffractionProblem(body=bd))
show(cpt.RadiationProblem(body=bd, wavenumber=3.0))

```