### PR TITLE
Fix variable names in libDelhommeau

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ develop:
 	pip install meson-python numpy charset-normalizer # No installed from pyproject.toml in this case...
 	pip install --no-build-isolation -e .
 
+test_fortran_compilation:
+	meson setup --wipe build_meson && meson compile -C build_meson -j 1
+
 test: develop
 	# TODO: use something like nox instead.
 	# TODO: Install pytest and hypothesis?
@@ -20,4 +23,4 @@ clean:
 	rm -rf .hypothesis/
 	rm -rf __pycache__ */__pycache__ */*/__pycache__ */*/*/__pycache__
 
-.PHONY: install develop test clean
+.PHONY: install develop test clean test_fortran_compilation

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test_fortran_compilation:
 
 test: develop
 	# TODO: use something like nox instead.
-	# TODO: Install pytest and hypothesis?
+	# TODO: Install pytest
 	python -m pytest
 
 clean:
@@ -20,7 +20,6 @@ clean:
 	rm -rf capytaine.egg-info/
 	rm -rf docs/_build
 	rm -rf .pytest_cache/
-	rm -rf .hypothesis/
 	rm -rf __pycache__ */__pycache__ */*/__pycache__ */*/*/__pycache__
 
 .PHONY: install develop test clean test_fortran_compilation

--- a/capytaine/green_functions/libDelhommeau/src/Green_wave.f90
+++ b/capytaine/green_functions/libDelhommeau/src/Green_wave.f90
@@ -302,8 +302,8 @@ CONTAINS
       SP               = SP               + AQT*SUM(FTS(1:4))
 
       VSP_ANTISYM(1:2) = VSP_ANTISYM(1:2) + AQT*(VTS(1:2, 1) + VTS(1:2, 2) + VTS(1:2, 3) + VTS(1:2, 4))
-      VSP_ANTISYM(3)   = VSP_SYM(3) + AQT*(VTS(3, 1) + VTS(3, 4))
-      VSP_SYM(3)       = VSP_ANTISYM(3) + AQT*(VTS(3, 2) + VTS(3, 3))
+      VSP_ANTISYM(3)   = VSP_ANTISYM(3) + AQT*(VTS(3, 1) + VTS(3, 4))
+      VSP_SYM(3)       = VSP_SYM(3) + AQT*(VTS(3, 2) + VTS(3, 3))
 
     END DO
 

--- a/capytaine/green_functions/libDelhommeau/src/matrices.f90
+++ b/capytaine/green_functions/libDelhommeau/src/matrices.f90
@@ -178,9 +178,8 @@ CONTAINS
                 quad_points(J, Q, :),       & ! centers_2(J, :),
                 wavenumber,                 &
                 tabulated_r_range, tabulated_z_range, tabulated_integrals, &
-                SP2, VSP2_SYM               &
+                SP2, VSP2_SYM, VSP2_ANTISYM &
                 )
-              VSP2_ANTISYM(:) = ZERO
             ELSE
               CALL WAVE_PART_FINITE_DEPTH   &
                 (centers_1(I, :),           &
@@ -232,9 +231,8 @@ CONTAINS
               quad_points(J, 1, :),       & ! centers_2(J, :),
               wavenumber,                 &
               tabulated_r_range, tabulated_z_range, tabulated_integrals, &
-              SP2, VSP2_SYM               &
+              SP2, VSP2_SYM, VSP2_ANTISYM &
               )
-            VSP2_ANTISYM(:) = ZERO
           ELSE
             CALL WAVE_PART_FINITE_DEPTH   &
               (centers_1(I, :),           &
@@ -256,7 +254,6 @@ CONTAINS
           endif
 
           IF (.NOT. I==J) THEN
-            VSP2_SYM(1:2) = -VSP2_SYM(1:2)
             S(J, I) = S(J, I) - coeffs(3) * SP2 * quad_weights(I, 1)
             if (size(K, 3) == 1) then
               K(J, I, 1) = K(J, I, 1) - coeffs(3) * &

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,14 @@ Bug fixes
 
 * Update the BEMIO import feature to work with Pandas 2.0 and output periods as now done in Capytaine 2.0. A version of BEMIO that works in recent version of Python and Numpy can be found at `https://github.com/mancellin/bemio`_. (:pull:`381`)
 
+Internals
+~~~~~~~~~
+
+* Fix badly named variables ``VSP2_SYM`` and ``VSP2_ANTISYM`` in libDelhommeau (:pull:`391`)
+
+* Remove dependency to ``hypothesis`` for testing (:pull:`391`).
+
+
 -------------------------------
 New in version 2.0 (2023-06-21)
 -------------------------------

--- a/docs/developer_manual/installation.rst
+++ b/docs/developer_manual/installation.rst
@@ -159,7 +159,7 @@ Testing
 To check that the installed packaged is working fine, you can run the test suite with Pytest.
 If the library is not already install, it can be done with::
 
-    pip install pytest hypothesis
+    pip install pytest
 
 Then run the following command from the root of Capytaine repository to test the code::
 

--- a/docs/theory_manual/theory.rst
+++ b/docs/theory_manual/theory.rst
@@ -355,7 +355,9 @@ that is, using :numref:`Lemma {number} <integrate_one_over_zeta>`
         \frac{\partial G}{\partial x_1} (\xi, x) = - \frac{\partial G}{\partial x_1}(x, \xi).
         \]
 
-    Its derivative with respect to :math:`x_3` can be decomposed into an antisymmetric term and a symmetric term.
+    Its derivative with respect to :math:`x_3` is symmetric in infinite depth.
+
+    In finite depth, some terms of the derivative with respect to :math:`x_3` are symmetric and some are antisymmetric.
 
 
 Higher order derivative

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dynamic = ['version']
 [project.optional-dependencies]
 ci = [
     "pytest",
-    "hypothesis",
     "bemio @ https://github.com/mancellin/bemio/archive/fa3a6d3d4b0862491c3723919ec8ee45cc7d055a.zip",
 ]
 
@@ -30,5 +29,5 @@ build-backend = 'mesonpy'
 requires = ["meson-python", "oldest-supported-numpy", "charset-normalizer"]
 
 [tool.cibuildwheel]
-test-requires = ["pytest", "hypothesis"]
+test-requires = ["pytest"]
 test-command = "pytest {project}/pytest/"


### PR DESCRIPTION
The term labelled "symmetric" and "anti-symmetric" were not actually what they claimed.