### PR TITLE
Refactor forces in result objects

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,7 @@ Internals
 
 * Remove dependency to ``hypothesis`` for testing (:pull:`391`).
 
+* Change how forces are stored in result objects. Added mass and radiation damping can now be queried with ``added_mass`` and ``radiation_damping`` and not only the plural forms that were used nowhere else in the code. (:pull:`393`)
 
 -------------------------------
 New in version 2.0 (2023-06-21)

--- a/pytest/test_bem_problems_and_results.py
+++ b/pytest/test_bem_problems_and_results.py
@@ -139,7 +139,7 @@ def test_radiation_problem(caplog):
     #     RadiationProblem(body=sphere)
 
     sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
-    pb = RadiationProblem(body=sphere)
+    pb = RadiationProblem(body=sphere, omega=1.0)
     assert len(pb.boundary_condition) == sphere.mesh.nb_faces
 
     sphere.add_translation_dof(direction=(1, 0, 0), name="Surge")
@@ -150,8 +150,12 @@ def test_radiation_problem(caplog):
 
     res = pb.make_results_container()
     assert isinstance(res, RadiationResult)
-    assert res.added_masses == {}
-    assert res.radiation_dampings == {}
+    assert res.added_mass == res.added_masses == {}
+    assert res.radiation_damping == res.radiation_dampings == {}
+
+    res = pb.make_results_container(forces={"Heave": 1.0 + 2.0j})
+    assert res.added_mass == res.added_masses == {"Heave": 1.0}
+    assert res.radiation_damping == res.radiation_dampings == {"Heave": 2.0}
 
 
 def test_Froude_Krylov():

--- a/pytest/test_bem_problems_and_results.py
+++ b/pytest/test_bem_problems_and_results.py
@@ -150,7 +150,6 @@ def test_radiation_problem(caplog):
 
     res = pb.make_results_container()
     assert isinstance(res, RadiationResult)
-    assert 'forces' not in res.__dict__
     assert res.added_masses == {}
     assert res.radiation_dampings == {}
 


### PR DESCRIPTION
Make both the radiation and diffraction results store forces in the same way under the hood.
Radiation forces can be converted to added mass/radiation damping on-the-fly when necessary.
Remove `store_force()`'s inheritance pattern that was pointlessly complicated.
Also allow to get `added_mass` and `radiation_damping` and not only the plural versions that were used nowhere else in the code.