### PR TITLE
Precompute the tabulation at compile time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ TEMP_DIR := $(shell mktemp -d)
 test_fortran_compilation:
 	# Compile the Fortran code without parallelism for easier reading of the errors.
 	# It is assumed that meson and ninja are already installed.
-	meson setup --wipe $(TEMP_DIR) && meson compile -C $(TEMP_DIR) -j 1
+	meson setup --wipe $(TEMP_DIR) && meson compile -C $(TEMP_DIR) -j 1 foo
+	echo $(TEMP_DIR)
 
 test:
 	# Build and test the current repository in a fixed environment.

--- a/capytaine/green_functions/delhommeau.py
+++ b/capytaine/green_functions/delhommeau.py
@@ -98,6 +98,9 @@ class Delhommeau(AbstractGreenFunction):
     def _repr_pretty_(self, p, cycle):
         p.text(self.__str__())
 
+    def write_tabulation_to_file(self, filename):
+        np.save(filename, self.tabulated_integrals)
+
     @lru_cache(maxsize=128)
     def find_best_exponential_decomposition(self, dimensionless_omega, dimensionless_wavenumber):
         """Compute the decomposition of a part of the finite water_depth Green function as a sum of exponential functions.

--- a/meson.build
+++ b/meson.build
@@ -75,7 +75,7 @@ py3.extension_module('Delhommeau_float32',
            install : true,
            subdir : 'capytaine/green_functions/libs/')
 
-py3.extension_module('Delhommeau_float64',
+del64 = py3.extension_module('Delhommeau_float64',
            float64, libDelhommeau_src, Delhommeau_float64_f2py_wrapper, incdir_f2py+'/fortranobject.c',
            include_directories: inc_np,
            dependencies : deps,
@@ -101,3 +101,5 @@ py3.extension_module('XieDelhommeau_float64',
            link_args : link_args,
            install : true,
            subdir : 'capytaine/green_functions/libs/')
+
+custom_target('foo', output: 'test.npy', command: [py3, '-c', 'from capytaine import Delhommeau; Delhommeau().write_tabulation_to_file("test.npy")'], depends: [del64])


### PR DESCRIPTION
Instead of building the Green function tabulation at each initialization of the BEMSolver, a tabulation could be stored in a file and loaded at initialization.

There are several options:
- Compute it at first initialization, store it in a cache directory and reuse it when required.
- Compute it at compile time, ship it in the precompiled package on PyPI or conda-forge. Only the default tabulation would be precomputed, as it is sufficient for 99% of users. It would approximately double the size of the package...

Right now, I'm investigating the second option, but maybe the first one is more pragmatic.