### PR TITLE
More generic RAO computation

### DIFF
--- a/capytaine/io/xarray.py
+++ b/capytaine/io/xarray.py
@@ -351,6 +351,7 @@ def assemble_dataset(results,
         diffraction_cases.wave_direction.attrs['long_name'] = 'Wave direction'
         diffraction_cases.wave_direction.attrs['units'] = 'rad'
         dataset = xr.merge([dataset, diffraction_cases])
+        dataset['excitation_force'] = dataset['Froude_Krylov_force'] + dataset['diffraction_force']
 
     # OTHER FREQUENCIES TYPES
     if omega and main_freq_type != "omega":

--- a/capytaine/post_pro/impedance.py
+++ b/capytaine/post_pro/impedance.py
@@ -30,10 +30,10 @@ def rao_transfer_function(dataset, dissipation=None, stiffness=None):
     """
 
     if not hasattr(dataset, 'inertia_matrix'):
-        raise AttributeError('Computing the impedance matrix requires a :code:`inertia_matrix` matrix to be defined in the hydrodynamical dataset')
+        raise AttributeError('Computing the impedance matrix requires an `inertia_matrix` matrix to be defined in the hydrodynamical dataset')
 
     if not hasattr(dataset, 'hydrostatic_stiffness'):
-        raise AttributeError('Computing the impedance matrix requires a :code:`hydrostatic_stiffness` matrix to be defined in the hydrodynamical dataset')
+        raise AttributeError('Computing the impedance matrix requires an `hydrostatic_stiffness` matrix to be defined in the hydrodynamical dataset')
 
     # ASSEMBLE MATRICES
     omega = dataset.coords['omega']  # Range of frequencies in the dataset

--- a/capytaine/post_pro/rao.py
+++ b/capytaine/post_pro/rao.py
@@ -53,6 +53,8 @@ def rao(dataset, wave_direction=None, dissipation=None, stiffness=None):
         fex = fex.sel(wave_direction=wave_direction)
 
     # Solve and add coordinates
-    rao = xr.DataArray(np.linalg.solve(H, fex), coords=fex.coords, dims=fex.dims)
+    rao_dims = [d for d in H.dims if d != 'influenced_dof']
+    rao_coords = {c: H.coords[c] for c in H.coords if c != 'influenced_dof'}
+    rao = xr.DataArray(np.linalg.solve(H, fex), coords=rao_coords, dims=rao_dims)
 
     return rao

--- a/capytaine/post_pro/rao.py
+++ b/capytaine/post_pro/rao.py
@@ -11,7 +11,7 @@ from capytaine.post_pro.impedance import rao_transfer_function
 LOG = logging.getLogger(__name__)
 
 
-def rao(dataset, wave_direction=0.0, dissipation=None, stiffness=None):
+def rao(dataset, wave_direction=None, dissipation=None, stiffness=None):
     """Response Amplitude Operator.
 
     Parameters
@@ -21,8 +21,8 @@ def rao(dataset, wave_direction=0.0, dissipation=None, stiffness=None):
         This function supposes that variables named 'inertia_matrix' and 'hydrostatic_stiffness' are in the dataset.
         Other variables can be computed by Capytaine, by those two should be manually added to the dataset.
     wave_direction: float, optional
-        The direction of the incoming waves.
-        Default: 0 radian (x direction)
+        Select a wave directions for the computation. (Not recommended, kept for legacy.)
+        Default: all wave directions in the dataset.
     dissipation: array, optional
         An optional dissipation matrix (e.g. Power Take Off) to be included in the RAO.
         Default: none.
@@ -38,26 +38,21 @@ def rao(dataset, wave_direction=0.0, dissipation=None, stiffness=None):
 
     # ASSEMBLE MATRICES
     H = rao_transfer_function(dataset, dissipation, stiffness)
+    fex = dataset.excitation_force
 
     LOG.info("Compute RAO.")
 
-    freq_dims = set(dataset.dims) & {'omega', 'period', 'wavelength', 'wavenumber'}
-    if len(freq_dims) != 1:
-        raise ValueError("The dataset provided to compute the RAO should one (and only one) dimension" +
-                         " among the following: 'omega', 'period', 'wavelength' or 'wavenumber'\n" +
-                         f"The received dataset has the following dimensions: {dataset.dims}")
-    main_freq_type = freq_dims.pop()
-
-    if 'excitation_force' not in dataset:
-        dataset['excitation_force'] = dataset['Froude_Krylov_force'] + dataset['diffraction_force']
-    excitation = dataset['excitation_force'].sel(wave_direction=wave_direction)
-
     # SOLVE LINEAR SYSTEMS
-    # Reorder dimensions of the arrays to be sure to solve the right system.
-    H = H.transpose(main_freq_type, 'radiating_dof', 'influenced_dof')
-    excitation = excitation.transpose(main_freq_type,  'influenced_dof')
+    # Match dimensions of the arrays to be sure to solve the right systems.
+    H, fex = xr.broadcast(H, fex, exclude=["radiating_dof", "influenced_dof"])
+    H = H.transpose(..., 'radiating_dof', 'influenced_dof')
+    fex = fex.transpose(...,  'influenced_dof')
 
-    # Solve the linear systems (one for each value of omega)
-    X = np.linalg.solve(H, excitation)
+    if wave_direction is not None:  # Legacy behavior for backward compatibility
+        H = H.sel(wave_direction=wave_direction)
+        fex = fex.sel(wave_direction=wave_direction)
 
-    return xr.DataArray(X, coords=[dataset.coords[main_freq_type], dataset.coords['radiating_dof']], dims=[main_freq_type, 'radiating_dof'])
+    # Solve and add coordinates
+    rao = xr.DataArray(np.linalg.solve(H, fex), coords=fex.coords, dims=fex.dims)
+
+    return rao

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,11 @@ Minor changes
 
 * Clean up ``__str__`` and ``__repr__`` representation of many objects. Also `rich.print` now return even nicer representations. (:pull:`384`)
 
+* Always automatically compute and store the ``excitation_force`` next to the ``Froude_Krylov_force`` and ``diffraction_force`` in the dataset (:pull:`406`).
+
+* Computing the RAO with :func:`cpt.post_pro.rao.rao` is not restricted to a single wave direction (or a single value of any other extra parameter) at the time anymore. (:issue:`405` and :pull:`406`)
+
+
 Bug fixes
 ~~~~~~~~~
 

--- a/pytest/test_post_pro.py
+++ b/pytest/test_post_pro.py
@@ -98,14 +98,6 @@ def test_impedance_sphere_heave(sphere_heave_data):
     Zi = cpt.post_pro.impedance(sphere_heave_data)
 
 
-def test_malformed_dataset(sphere_heave_data):
-    data = sphere_heave_data.drop_vars("wavelength")
-    data = data.expand_dims({"wavelength": 1})
-    # data has both an "omega" dimension and a "wavelength" dimension
-    with pytest.raises(ValueError):
-        RAO = cpt.post_pro.rao(data)
-
-
 def test_rao_sphere_heave_indirect(sphere_heave_data):
     RAO = cpt.post_pro.rao(sphere_heave_data)
     assert RAO.radiating_dof.size == 1

--- a/pytest/test_post_pro.py
+++ b/pytest/test_post_pro.py
@@ -27,9 +27,11 @@ def sphere_fb():
             )
     return body
 
+@pytest.fixture
+def solver():
+    return cpt.BEMSolver()
 
-def test_rao_sphere_all(sphere_fb):
-    solver = cpt.BEMSolver()
+def test_rao_sphere_all(sphere_fb, solver):
     test_matrix = xr.Dataset(coords={
         'omega': np.linspace(0.5, 10.0, 5),
         'wave_direction': [0],
@@ -37,8 +39,8 @@ def test_rao_sphere_all(sphere_fb):
         })
 
     data = solver.fill_dataset(test_matrix, sphere_fb,
-                               hydrostatics=True, mesh=True,
-                               wavelength=True, wavenumber=True)
+                               hydrostatics=True, mesh=True)
+
 
     RAO = cpt.post_pro.rao(data)
 
@@ -50,9 +52,8 @@ def test_rao_sphere_all(sphere_fb):
     # # assert RAO == ? # TODO could test against known results
 
 
-def test_rao_from_wavelengths(sphere_fb):
+def test_rao_from_wavelengths(sphere_fb, solver):
     # From https://github.com/capytaine/capytaine/issues/316
-    solver = cpt.BEMSolver()
     test_matrix = xr.Dataset(coords={
         'wavelength': np.linspace(0.5, 10.0, 5),
         'wave_direction': [0],
@@ -64,11 +65,24 @@ def test_rao_from_wavelengths(sphere_fb):
     RAO = cpt.post_pro.rao(data)
 
 
+def test_rao_several_water_depth(sphere_fb, solver):
+    # From https://github.com/capytaine/capytaine/issues/405
+    test_matrix = xr.Dataset(coords={
+        'omega': np.linspace(0.5, 10.0, 3),
+        'wave_direction': [0],
+        'water_depth': [np.infty, 10.0],
+        'radiating_dof': list(sphere_fb.dofs.keys()),
+        })
+
+    data = solver.fill_dataset(test_matrix, sphere_fb, hydrostatics=True)
+    rao = cpt.post_pro.rao(data)
+    assert "water_depth" in rao.dims
+
+
 @pytest.fixture
-def sphere_heave_data(sphere_fb):
+def sphere_heave_data(sphere_fb, solver):
     sphere_fb.keep_only_dofs(['Heave'])
 
-    solver = cpt.BEMSolver()
     test_matrix = xr.Dataset(coords={
           'omega': np.linspace(0.5, 10.0, 5),
           'wave_direction': [0],


### PR DESCRIPTION
Fix #405

Also, compute the excitation for all datasets in `assemble_dataset`. (Because I don't see why not.)