### PR TITLE
Fix link to custom CSS

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,5 +1,6 @@
 {% extends "!layout.html" %}
 {% block extrahead %}
     <script defer data-domain="ancell.in/capytaine" src="https://plausible.io/js/script.js"></script>
+    <link rel="stylesheet" href="_static/custom.css" type="text/css" />
     {{super}}
 {% endblock %}


### PR DESCRIPTION
The commits 96d284d and 38e1972 were effectively useless because the custom css is not used for the generated pages.