### PR TITLE
Quadratures without dependencies

### DIFF
--- a/capytaine/meshes/meshes.py
+++ b/capytaine/meshes/meshes.py
@@ -15,7 +15,7 @@ from capytaine.meshes.surface_integrals import SurfaceIntegralsMixin
 from capytaine.meshes.quality import (merge_duplicates, heal_normals, remove_unused_vertices,
                                       heal_triangles, remove_degenerated_faces)
 from capytaine.tools.optional_imports import import_optional_dependency
-from capytaine.meshes.quadratures import compute_quadrature, DEFAULT_QUADRATURE
+from capytaine.meshes.quadratures import compute_quadrature_on_faces
 
 LOG = logging.getLogger(__name__)
 
@@ -330,9 +330,10 @@ class Mesh(ClippableMixin, SurfaceIntegralsMixin, Abstract3DObject):
         else:
             return None
 
-    def compute_quadrature(self, method=DEFAULT_QUADRATURE):
+    def compute_quadrature(self, method):
         self.heal_triangles()
-        points, weights = compute_quadrature(self, method)
+        all_faces = self.vertices[self.faces[:, :], :]
+        points, weights = compute_quadrature_on_faces(all_faces, method)
         self.__internals__['quadrature'] = (points, weights)
         self.__internals__['quadrature_method'] = method
         return points, weights

--- a/capytaine/meshes/meshes.py
+++ b/capytaine/meshes/meshes.py
@@ -346,19 +346,19 @@ class Mesh(ClippableMixin, SurfaceIntegralsMixin, Abstract3DObject):
 
             for i_face in range(self.nb_faces):
                 corners = self.vertices[self.faces[i_face, :]]
-                dxidx = (corners[0, :] + corners[1, :] - corners[2, :] - corners[3, :])/4
-                dxidy = (corners[0, :] - corners[1, :] - corners[2, :] + corners[3, :])/4
-                detJ = np.linalg.norm(np.cross(dxidx, dxidy))
 
                 for k_quad in range(nb_points):
-                    p = local_points[k_quad, :]
+                    xk, yk = local_points[k_quad, :]
                     points[i_face, k_quad, :] = (
-                              (1 + p[0])*(1 + p[1])/4 * corners[0, :]
-                            + (1 + p[0])*(1 - p[1])/4 * corners[1, :]
-                            + (1 - p[0])*(1 - p[1])/4 * corners[2, :]
-                            + (1 - p[0])*(1 + p[1])/4 * corners[3, :]
-                            )
-                    weights[i_face, k_quad] = local_weights[k_quad] * self.faces_areas[i_face] * detJ
+                              (1 + xk)*(1 + yk) * corners[0, :]
+                            + (1 + xk)*(1 - yk) * corners[1, :]
+                            + (1 - xk)*(1 - yk) * corners[2, :]
+                            + (1 - xk)*(1 + yk) * corners[3, :]
+                            )/4
+                    dxidx = ((1+yk)*corners[0, :] + (1-yk)*corners[1, :] - (1-yk)*corners[2, :] - (1+yk)*corners[3, :])/4
+                    dxidy = ((1+xk)*corners[0, :] - (1+xk)*corners[1, :] - (1-xk)*corners[2, :] + (1-xk)*corners[3, :])/4
+                    detJ = np.linalg.norm(np.cross(dxidx, dxidy))
+                    weights[i_face, k_quad] = local_weights[k_quad] * 4 * detJ
 
         else:
             try:

--- a/capytaine/meshes/quadratures.py
+++ b/capytaine/meshes/quadratures.py
@@ -6,10 +6,13 @@ from capytaine.tools.optional_imports import silently_import_optional_dependency
 
 LOG = logging.getLogger(__name__)
 
-# Quadrature methods are only defined for quadrilaterals. They also work for
+# The builtin methods are stored as a list of 2D-points in [-1, 1]² and a list
+# of corresponding weights. The 2D points will be remapped to the actual shape
+# of the faces. They are only defined for quadrilaterals. They also work for
 # triangles (although they might be subobtimal).
 
 builtin_methods = {
+        "First order": (np.array([(0.0, 0.0)]), np.array([1.0])),
         "Gauss-Legendre 2": (
             np.array([(+1/np.sqrt(3), +1/np.sqrt(3)),
              (+1/np.sqrt(3), -1/np.sqrt(3)),
@@ -19,10 +22,26 @@ builtin_methods = {
             )
         }
 
-DEFAULT_QUADRATURE = "Gauss-Legendre 2"
 
+def compute_quadrature_on_faces(faces, method):
+    """
+    Compute the quadrature points and weight for numerical integration over the faces.
 
-def compute_quadrature(mesh, method):
+    Parameters
+    ----------
+    faces: array of shape (nb_faces, 4, 3)
+        The 3D-coordinates of each of the 4 corners of each face.
+    method: string or quadpy object
+        The method used to compute the quadrature scheme
+
+    Returns
+    -------
+    points: array of shape (nb_faces, nb_quad_points, 3)
+        The 3D-coordinates of each of the quadrature points (their number depends on the method) of each face.
+    weights: array of shape (nb_faces, nb_quad_points)
+        Weights associated to each of the quadrature points.
+    """
+
     if method in builtin_methods:
         LOG.debug("Quadrature method found in builtin methods.")
         local_points, local_weights = builtin_methods[method]
@@ -37,23 +56,24 @@ def compute_quadrature(mesh, method):
         raise ValueError(f"Unrecognized quadrature scheme: {method}.\n"
                          f"Consider using one of the following: {set(builtin_methods.keys())}")
 
-    nb_points = len(local_weights)
-    points = np.empty((mesh.nb_faces, nb_points, 3))
-    weights = np.empty((mesh.nb_faces, nb_points))
+    nb_faces = faces.shape[0]
+    nb_quad_points = len(local_weights)
+    points = np.empty((nb_faces, nb_quad_points, 3))
+    weights = np.empty((nb_faces, nb_quad_points))
 
-    for i_face in range(mesh.nb_faces):
-        corners = mesh.vertices[mesh.faces[i_face, :]]
-
-        for k_quad in range(nb_points):
+    for i_face in range(nb_faces):
+        for k_quad in range(nb_quad_points):
             xk, yk = local_points[k_quad, :]
             points[i_face, k_quad, :] = (
-                      (1 + xk)*(1 + yk) * corners[0, :]
-                    + (1 + xk)*(1 - yk) * corners[1, :]
-                    + (1 - xk)*(1 - yk) * corners[2, :]
-                    + (1 - xk)*(1 + yk) * corners[3, :]
+                      (1+xk)*(1+yk) * faces[i_face, 0, :]
+                    + (1+xk)*(1-yk) * faces[i_face, 1, :]
+                    + (1-xk)*(1-yk) * faces[i_face, 2, :]
+                    + (1-xk)*(1+yk) * faces[i_face, 3, :]
                     )/4
-            dxidx = ((1+yk)*corners[0, :] + (1-yk)*corners[1, :] - (1-yk)*corners[2, :] - (1+yk)*corners[3, :])/4
-            dxidy = ((1+xk)*corners[0, :] - (1+xk)*corners[1, :] - (1-xk)*corners[2, :] + (1-xk)*corners[3, :])/4
+            dxidx = ((1+yk)*faces[i_face, 0, :] + (1-yk)*faces[i_face, 1, :]
+                     - (1-yk)*faces[i_face, 2, :] - (1+yk)*faces[i_face, 3, :])/4
+            dxidy = ((1+xk)*faces[i_face, 0, :] - (1+xk)*faces[i_face, 1, :]
+                     - (1-xk)*faces[i_face, 2, :] + (1-xk)*faces[i_face, 3, :])/4
             detJ = np.linalg.norm(np.cross(dxidx, dxidy))
             weights[i_face, k_quad] = local_weights[k_quad] * 4 * detJ
 

--- a/capytaine/meshes/quadratures.py
+++ b/capytaine/meshes/quadratures.py
@@ -1,0 +1,60 @@
+import logging
+
+import numpy as np
+
+from capytaine.tools.optional_imports import silently_import_optional_dependency
+
+LOG = logging.getLogger(__name__)
+
+# Quadrature methods are only defined for quadrilaterals. They also work for
+# triangles (although they might be subobtimal).
+
+builtin_methods = {
+        "Gauss-Legendre 2": (
+            np.array([(+1/np.sqrt(3), +1/np.sqrt(3)),
+             (+1/np.sqrt(3), -1/np.sqrt(3)),
+             (-1/np.sqrt(3), +1/np.sqrt(3)),
+             (-1/np.sqrt(3), -1/np.sqrt(3))]),
+            np.array([1/4, 1/4, 1/4, 1/4])
+            )
+        }
+
+DEFAULT_QUADRATURE = "Gauss-Legendre 2"
+
+
+def compute_quadrature(mesh, method):
+    if method in builtin_methods:
+        LOG.debug("Quadrature method found in builtin methods.")
+        local_points, local_weights = builtin_methods[method]
+
+    elif ((quadpy := silently_import_optional_dependency("quadpy")) is not None
+                and isinstance(method, quadpy.c2._helpers.C2Scheme)):
+        LOG.debug("Quadrature method is a Quadpy scheme: %s", method.name)
+        local_points = method.points.T
+        local_weights = method.weights
+
+    else:
+        raise ValueError(f"Unrecognized quadrature scheme: {method}.\n"
+                         f"Consider using one of the following: {set(builtin_methods.keys())}")
+
+    nb_points = len(local_weights)
+    points = np.empty((mesh.nb_faces, nb_points, 3))
+    weights = np.empty((mesh.nb_faces, nb_points))
+
+    for i_face in range(mesh.nb_faces):
+        corners = mesh.vertices[mesh.faces[i_face, :]]
+
+        for k_quad in range(nb_points):
+            xk, yk = local_points[k_quad, :]
+            points[i_face, k_quad, :] = (
+                      (1 + xk)*(1 + yk) * corners[0, :]
+                    + (1 + xk)*(1 - yk) * corners[1, :]
+                    + (1 - xk)*(1 - yk) * corners[2, :]
+                    + (1 - xk)*(1 + yk) * corners[3, :]
+                    )/4
+            dxidx = ((1+yk)*corners[0, :] + (1-yk)*corners[1, :] - (1-yk)*corners[2, :] - (1+yk)*corners[3, :])/4
+            dxidy = ((1+xk)*corners[0, :] - (1+xk)*corners[1, :] - (1-xk)*corners[2, :] + (1-xk)*corners[3, :])/4
+            detJ = np.linalg.norm(np.cross(dxidx, dxidy))
+            weights[i_face, k_quad] = local_weights[k_quad] * 4 * detJ
+
+    return points, weights

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,7 @@ Minor changes
 
 * Computing the RAO with :func:`cpt.post_pro.rao.rao` is not restricted to a single wave direction (or a single value of any other extra parameter) at the time anymore. (:issue:`405` and :pull:`406`)
 
+* New computation of quadrature schemes without relying on Quadpy. (:pull:`416`)
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/user_manual/mesh.rst
+++ b/docs/user_manual/mesh.rst
@@ -266,28 +266,31 @@ If none of them are define, the rotation is defined around the origin of the dom
 Defining an integration quadrature
 ----------------------------------
 
-.. warning:: This feature is experimental.
-             Only quadrilaterals panels are supported at the moment.
-
 During the resolution of the BEM problem, the Green function has to be
-integrated on the mesh. By default, the integration is approximated by taking
-the value at the center of the panel and multiplying by its area. For a more
-accurate intagration, an higher order quadrature can be defined.
+integrated on each panel of the mesh. Parts of the Green function (such as the
+:math:`1/r` Rankine terms) are integrated using an exact analytical expression
+for the integral. Other parts of the Green function rely on numerical
+integration. By default, this numerical integration is done by taking the value
+at the center of the panel and multiplying by its area. For a more accurate
+intagration, an higher order quadrature can be defined.
 
-This feature relies on the external package `quadpy` to compute the quadrature.
-You can install it with::
+To define a quadrature scheme for a mesh, run the following command::
 
-    pip install quadpy
+    body.mesh.compute_quadrature(method="Gauss-Legendre 2")
 
-Then chose one of the `available quadratures
-<https://github.com/nschloe/quadpy#quadrilateral>`_ and give it to the
-:code:`compute_quadrature` method::
+The quadrature data can then be accessed at::
 
-    from quadpy.quadrilateral import stroud_c2_7_2
+    body.mesh.quadrature_points
 
-    body.mesh.compute_quadrature(method=stroud_c2_7_2())
-
-It will then be used automatically when needed.
+and will be used automatically when needed.
 
 .. warning:: Transformations of the mesh (merging, clipping, ...) may reset the quadrature.
              Compute it only on your final mesh.
+
+.. warning:: Quadratures schemes have been designed with quadrilateral panels.
+             They work on triangular panels, but might not be as optimal then.
+
+Alternatively, the :meth:`~capytaine.meshes.quadratures.compute_quadrature` method also accepts methods from the `Quadpy` package::
+
+    import quadpy
+    body.mesh.compute_quadrature(method=quadpy.c2.get_good_scheme(8))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ scripts = {capytaine = "capytaine.ui.cli:main"}
 dynamic = ['version']
 
 [project.optional-dependencies]
-optional = ["matplotlib", "joblib>=1.3", "meshio", "bemio @ https://github.com/mancellin/bemio/archive/fa3a6d3d4b0862491c3723919ec8ee45cc7d055a.zip"]
+optional = ["matplotlib", "joblib>=1.3", "meshio", "quadpy-gpl", "bemio @ https://github.com/mancellin/bemio/archive/fa3a6d3d4b0862491c3723919ec8ee45cc7d055a.zip"]
 build = ["numpy", "ninja", "meson-python", "charset-normalizer"]
 test = ["pytest"]
 docs = ["sphinx", "sphinx-toolbox", "sphinxcontrib-proof", "sphinxcontrib-mermaid"]

--- a/pytest/test_bem_with_quadratures.py
+++ b/pytest/test_bem_with_quadratures.py
@@ -12,6 +12,13 @@ except ImportError:
     quadpy = None
 
 
+def test_quadrature_trivial_panel():
+    mesh = cpt.Mesh(vertices=np.array([[-1, -1, 0], [-1, 1, 0], [1, 1, 0], [1, -1, 0]]), faces=np.array([[0, 1, 2, 3]]))
+    mesh.compute_quadrature("GL2")
+    points, weights = mesh.quadrature_points
+    assert np.sum(weights) == pytest.approx(mesh.faces_areas[0])
+
+
 @pytest.mark.skipif(quadpy is None, reason="quadpy is not installed")
 def test_quadrature_points_are_coplanar():
     # Check that all quadrature points are within the plane containing the panel

--- a/pytest/test_bem_with_quadratures.py
+++ b/pytest/test_bem_with_quadratures.py
@@ -1,22 +1,20 @@
-#!/usr/bin/env python
-# coding: utf-8
-
 import pytest
 import numpy as np
 import xarray as xr
 import capytaine as cpt
 
+try:
+    import quadpy
+    quadpy_methods = [quadpy.c2.schemes['sommariva_05']()]
+except ImportError:
+    quadpy_methods = []
 
-builtin_methods = ['GL2']
-quadpy_methods = ['sommariva_05']
+from capytaine.meshes.quadratures import builtin_methods
 
-@pytest.mark.parametrize('method', builtin_methods + quadpy_methods)
+@pytest.mark.parametrize('method', list(builtin_methods) + quadpy_methods)
 def test_quadrature_points_are_coplanar(method):
     # Check that all quadrature points are within the plane containing the panel
     mesh = cpt.mesh_sphere()
-    if method not in builtin_methods:
-        quadpy = pytest.importorskip("quadpy", reason="Quadpy not installed, test skipped.")
-        method = quadpy.c2.schemes[method]()
     mesh.compute_quadrature(method)
     for i_face in range(mesh.nb_faces):
         A, B, C, D = mesh.vertices[mesh.faces[i_face, :], :]
@@ -25,19 +23,16 @@ def test_quadrature_points_are_coplanar(method):
             assert np.isclose(np.dot(np.cross(B-A, C-A), X-A), 0.0, atol=1e-8)
 
 
-@pytest.mark.parametrize('method', builtin_methods + quadpy_methods)
+@pytest.mark.parametrize('method', list(builtin_methods) + quadpy_methods)
 def test_area(method):
     # Check that quadrature weights sum to the area of the panel
     mesh = cpt.mesh_sphere()
-    if method not in builtin_methods:
-        quadpy = pytest.importorskip("quadpy", reason="Quadpy not installed, test skipped.")
-        method = quadpy.c2.schemes[method]()
     mesh.compute_quadrature(method)
     for i_face in range(mesh.nb_faces):
         assert np.isclose(np.sum(mesh.quadrature_points[1][i_face, :]), mesh.faces_areas[i_face], rtol=1e-2)
 
 
-@pytest.mark.parametrize('method', builtin_methods + quadpy_methods)
+@pytest.mark.parametrize('method', list(builtin_methods) + quadpy_methods)
 def test_resolution(method):
     mesh = cpt.mesh_horizontal_cylinder(
         length=5.0, radius=1.0,
@@ -56,11 +51,16 @@ def test_resolution(method):
 
     data_0 = solver.fill_dataset(test_matrix, [body], mesh=True)
 
-    if method not in builtin_methods:
-        quadpy = pytest.importorskip("quadpy", reason="Quadpy not installed, test skipped.")
-        body.mesh.compute_quadrature(quadpy.c2.schemes[method]())
-    else:
-        body.mesh.compute_quadrature(method)
+    body.mesh.compute_quadrature(method)
     data_1 = solver.fill_dataset(test_matrix, [body], mesh=True)
 
     assert np.allclose(data_0["added_mass"].data, data_1["added_mass"].data, rtol=1e-1)
+
+
+# def test_triangular_mesh()
+#     mesh = cpt.Mesh(
+#         vertices=np.array([[0.0, 0.0, -1.0], [1.0, 0.0, -1.0], [0.0, 1.0, -1.0], [0.0, 0.0, -1.0]]),
+#         faces=np.array([[0, 1, 2, 3]])
+#     )
+#     mesh.compute_quadrature("GL2")
+#     points, weights = mesh.quadrature_points


### PR DESCRIPTION
The goal is to have higher-order integration scheme on some panels of the mesh sometimes (in particular, on the free surface for lid-based irregular frequencies removal).
Since Quadpy went commercial and closed-source, it cannot be required for the user to install it.
Instead, simple quadrature schemes can easily be implemented in Capytaine directly.