### PR TITLE
Rephrase mesh resolution warnings

### DIFF
--- a/capytaine/bem/problems_and_results.py
+++ b/capytaine/bem/problems_and_results.py
@@ -165,13 +165,6 @@ class LinearPotentialFlowProblem:
                     "or use body.keep_immersed_part() to clip the mesh."
                 )
 
-            if self.wavelength < self.body.minimal_computable_wavelength:
-                LOG.warning(f"Mesh resolution for {self}:\n"
-                        f"The resolution of the mesh '{self.body.mesh.name}' of the body '{self.body.name}' "
-                        f"might be insufficient for the wavelength λ={self.wavelength:.2e}.\n"
-                        f"This warning appears because the largest panel of this mesh has radius {self.body.mesh.faces_radiuses.max():.2e} > λ/8."
-                        )
-
         if self.boundary_condition is not None:
             if len(self.boundary_condition.shape) != 1:
                 raise ValueError("Expected a 1-dimensional array as boundary_condition")

--- a/capytaine/bem/solver.py
+++ b/capytaine/bem/solver.py
@@ -71,7 +71,7 @@ class BEMSolver:
     def from_exported_settings(settings):
         raise NotImplementedError
 
-    def solve(self, problem, keep_details=True):
+    def solve(self, problem, keep_details=True, _check_wavelength=True):
         """Solve the linear potential flow problem.
 
         Parameters
@@ -81,6 +81,8 @@ class BEMSolver:
         keep_details: bool, optional
             if True, store the sources and the potential on the floating body in the output object
             (default: True)
+        _check_wavelength: bool, optional
+            if True, check the mesh resolution with respect to the wavelength
 
         Returns
         -------
@@ -88,6 +90,8 @@ class BEMSolver:
             an object storing the problem data and its results
         """
         LOG.info("Solve %s.", problem)
+
+        if _check_wavelength: self._check_wavelength([problem])
 
         S, K = self.engine.build_matrices(
             problem.body.mesh, problem.body.mesh,
@@ -129,11 +133,12 @@ class BEMSolver:
         list of LinearPotentialFlowResult
             the solved problems
         """
+        self._check_wavelength(problems)
         if n_jobs == 1:  # force sequential resolution
             problems = sorted(problems)
             if progress_bar:
                 problems = track(problems, total=len(problems), description="Solving BEM problems")
-            return [self.solve(pb, **kwargs) for pb in problems]
+            return [self.solve(pb, _check_wavelength=False, **kwargs) for pb in problems]
         else:
             joblib = silently_import_optional_dependency("joblib")
             if joblib is None:
@@ -147,6 +152,33 @@ class BEMSolver:
                                           description=f"Solving BEM problems with {n_jobs} threads:")
             results = [res for grp in groups_of_results for res in grp]  # flatten the nested list
             return results
+
+    @staticmethod
+    def _check_wavelength(problems):
+        """Display a warning if some of the problems have a mesh resolution
+        that might not be sufficient for the given wavelength."""
+        risky_problems = [pb for pb in problems
+                          if pb.wavelength < pb.body.minimal_computable_wavelength]
+        nb_risky_problems = len(risky_problems)
+        if nb_risky_problems == 1:
+            pb = risky_problems[0]
+            freq_type = risky_problems[0].provided_freq_type
+            freq = pb.__getattribute__(freq_type)
+            LOG.warning(f"Mesh resolution for {pb}:\n"
+                    f"The resolution of the mesh of the body {pb.body.__short_str__()} might "
+                    f"be insufficient for {freq_type}={freq}.\n"
+                     "This warning appears because the largest panel of this mesh "
+                    f"has radius {pb.body.mesh.faces_radiuses.max():.3f} > wavelength/8."
+                    )
+        elif nb_risky_problems > 1:
+            freq_type = risky_problems[0].provided_freq_type
+            freqs = np.array([pb.__getattribute__(freq_type) for pb in risky_problems])
+            LOG.warning(f"Mesh resolution for {nb_risky_problems} problems:\n"
+                         "The resolution of the mesh might be insufficient "
+                        f"for {freq_type} ranging from {freqs.min():.3f} to {freqs.max():.3f}.\n"
+                         "This warning appears when the largest panel of this mesh "
+                         "has radius > wavelength/8."
+                    )
 
     def fill_dataset(self, dataset, bodies, *, n_jobs=1, **kwargs):
         """Solve a set of problems defined by the coordinates of an xarray dataset.

--- a/capytaine/bodies/bodies.py
+++ b/capytaine/bodies/bodies.py
@@ -82,11 +82,8 @@ class FloatingBody(ClippableMixin, Abstract3DObject):
         else:
             self.center_of_mass = None
 
-        if self.mesh.nb_vertices == 0 or self.mesh.nb_faces == 0:
-            LOG.warning(f"New floating body (with empty mesh!): {self.name}.")
-        else:
+        if self.mesh.nb_vertices > 0 and self.mesh.nb_faces > 0:
             self.mesh.heal_mesh()
-            LOG.info(f"New floating body: {self.name}.")
 
         if dofs is None:
             self.dofs = {}
@@ -97,6 +94,8 @@ class FloatingBody(ClippableMixin, Abstract3DObject):
             self.add_all_rigid_body_dofs()
         else:
             self.dofs = dofs
+
+        LOG.info(f"New floating body: {self.__str__()}.")
 
     @staticmethod
     def from_meshio(mesh, name=None) -> 'FloatingBody':

--- a/capytaine/meshes/quality.py
+++ b/capytaine/meshes/quality.py
@@ -263,7 +263,7 @@ def heal_normals(mesh):
             LOG.debug('\t--> Every normals have been reversed to be outward')
 
     else:
-        LOG.info("\t--> Mesh is not closed, meshmagick cannot test if the normals are outward")
+        LOG.debug("\t--> Mesh is not closed, Capytaine cannot test if the normals are outward")
 
     return mesh
 

--- a/capytaine/ui/rich.py
+++ b/capytaine/ui/rich.py
@@ -2,4 +2,4 @@ import logging
 from rich.logging import RichHandler
 
 def set_logging(level="INFO"):
-    logging.basicConfig(level=level, format="%(message)s", handlers=[RichHandler(level=level, show_path=False)], force=True)
+    logging.basicConfig(level=level, format="%(message)s", handlers=[RichHandler(level=level, log_time_format="[%X]", show_path=False)], force=True)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,6 +37,8 @@ Minor changes
 
 * Add a new function :func:`~capytaine.io.legacy.run_cal_file` to solve the problems defined by a Nemoh.cal file, exactly as the command-line interface is doing (:pull:`422`).
 
+* Rephrase mesh resolution warnings and group several of them together in a single warning. (:pull:`423`)
+
 Bug fixes
 ~~~~~~~~~
 


### PR DESCRIPTION
Since BEM problems are usually solved in batches, the problems with insufficient mesh resolution do not come alone. Instead of filling the screen with warnings, the new check displays a single warning for all the risky problems.