### PR TITLE
Update cibuildwheel to fix issue with recent Windows images

### DIFF
--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -27,7 +27,7 @@ jobs:
           version: '13'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_SKIP: "pp* *i686* *musllinux* *win32*"
         # Package the DLL dependencies in the wheel for windows (done by default for the other platforms).


### PR DESCRIPTION
The Windows wheel-building Github Action was broken due to an update of the environment used by the Action. It is fixed by updating cibuildwheel.