### PR TITLE
Generate mesh with a cell size instead of a number of cells

### DIFF
--- a/capytaine/meshes/predefined/cylinders.py
+++ b/capytaine/meshes/predefined/cylinders.py
@@ -150,7 +150,7 @@ def mesh_vertical_cylinder(*, length=10.0, radius=1.0, center=(0, 0, 0),
                 )
         if estimated_max_radius > faces_max_radius:
             nr = int(np.ceil(radius / (np.sqrt(2) * faces_max_radius)))
-            ntheta = int(np.ceil(2*pi*radius / (np.sqrt(2) * faces_max_radius)))
+            ntheta = 2*int(np.ceil(pi*radius / (np.sqrt(2) * faces_max_radius)))
             nz = int(np.ceil(length / (np.sqrt(2) * faces_max_radius)))
 
     if name is None:
@@ -257,7 +257,7 @@ def mesh_horizontal_cylinder(*, length=10.0, radius=1.0, center=(0, 0, 0),
                 )
         if estimated_max_radius > faces_max_radius:
             nr = int(np.ceil(radius / (np.sqrt(2) * faces_max_radius)))
-            ntheta = int(np.ceil(2*pi*radius / (np.sqrt(2) * faces_max_radius)))
+            ntheta = 2*int(np.ceil(pi*radius / (np.sqrt(2) * faces_max_radius)))
             nx = int(np.ceil(length / (np.sqrt(2) * faces_max_radius)))
 
     if reflection_symmetry:

--- a/capytaine/meshes/predefined/cylinders.py
+++ b/capytaine/meshes/predefined/cylinders.py
@@ -17,7 +17,7 @@ LOG = logging.getLogger(__name__)
 
 
 def mesh_disk(*, radius=1.0, center=(0, 0, 0), normal=(0, 0, 1),
-        resolution=(3, 6),
+        resolution=(3, 6), faces_max_radius=None,
         reflection_symmetry=False, axial_symmetry=False, name=None, _theta_max=2*pi):
     """(One-sided) disk.
 
@@ -31,6 +31,10 @@ def mesh_disk(*, radius=1.0, center=(0, 0, 0), normal=(0, 0, 1),
         normal vector, default: along x axis
     resolution : 2-ple of int, optional
         number of panels along a radius and around the disk
+    faces_max_radius : float, optional
+        maximal radius of a panel. (Default: no maximal radius.)
+        If the provided resolution is too coarse, the number of panels is
+        changed to fit the constraint on the maximal radius.
     axial_symmetry : bool, optional
         if True, returns an AxialSymmetricMesh
     reflection_symmetry : bool, optional
@@ -49,6 +53,13 @@ def mesh_disk(*, radius=1.0, center=(0, 0, 0), normal=(0, 0, 1),
     assert len(center) == 3, "Position of the center of a disk should be given a 3-ple of values."
 
     nr, ntheta = resolution
+    if faces_max_radius is not None:
+        # The biggest cell is on the side of the disk.
+        # Assuming it is a rectangle of sides radius/nr and perimeter/ntheta
+        estimated_max_radius = np.hypot(radius/nr, 2*pi*radius/ntheta)/2
+        if estimated_max_radius > faces_max_radius:
+            nr = int(np.ceil(radius / (np.sqrt(2) * faces_max_radius)))
+            ntheta = int(np.ceil(2*pi*radius / (np.sqrt(2) * faces_max_radius)))
 
     if name is None:
         name = f"disk_{next(Mesh._ids)}"
@@ -91,7 +102,8 @@ def mesh_disk(*, radius=1.0, center=(0, 0, 0), normal=(0, 0, 1),
 
 
 def mesh_vertical_cylinder(*, length=10.0, radius=1.0, center=(0, 0, 0),
-        resolution=(2, 8, 10), axial_symmetry=False, reflection_symmetry=False, name=None, _theta_max=2*pi):
+        resolution=(2, 8, 10), faces_max_radius=None,
+        axial_symmetry=False, reflection_symmetry=False, name=None, _theta_max=2*pi):
     """Vertical cylinder.
 
     Total number of panels = (2*resolution[0] + resolution[2])*resolution[1]
@@ -107,6 +119,10 @@ def mesh_vertical_cylinder(*, length=10.0, radius=1.0, center=(0, 0, 0),
     resolution : 3-ple of int, optional
         (number of panel along a radius at the end, number of panels around a slice, number of slices)
         Mnemonic: same ordering as the cylindrical coordinates (nr, ntheta, nz)
+    faces_max_radius : float, optional
+        maximal radius of a panel. (Default: no maximal radius.)
+        If the provided resolution is too coarse, the number of panels is
+        changed to fit the constraint on the maximal radius.
     axial_symmetry : bool, optional
         if True, returns an AxialSymmetricMesh
     reflection_symmetry : bool, optional
@@ -126,6 +142,16 @@ def mesh_vertical_cylinder(*, length=10.0, radius=1.0, center=(0, 0, 0),
     assert len(center) == 3, "Position of the center of a cylinder should be given a 3-ple of values."
 
     nr, ntheta, nz = resolution
+    if faces_max_radius is not None:
+        dr, dtheta, dz = radius/nr, 2*pi*radius/ntheta, length/nz
+        estimated_max_radius = max(
+                np.hypot(dr, dtheta)/2,  # Panel on disk side
+                np.hypot(dtheta, dz)/2,  # Panel on cylinder itself
+                )
+        if estimated_max_radius > faces_max_radius:
+            nr = int(np.ceil(radius / (np.sqrt(2) * faces_max_radius)))
+            ntheta = int(np.ceil(2*pi*radius / (np.sqrt(2) * faces_max_radius)))
+            nz = int(np.ceil(length / (np.sqrt(2) * faces_max_radius)))
 
     if name is None:
         name = f"cylinder_{next(Mesh._ids)}"
@@ -177,7 +203,8 @@ def mesh_vertical_cylinder(*, length=10.0, radius=1.0, center=(0, 0, 0),
 
 
 def mesh_horizontal_cylinder(*, length=10.0, radius=1.0, center=(0, 0, 0),
-        resolution=(2, 8, 10), reflection_symmetry=False, translation_symmetry=False, name=None, _theta_max=2*pi):
+        resolution=(2, 8, 10), faces_max_radius=None,
+        reflection_symmetry=False, translation_symmetry=False, name=None, _theta_max=2*pi):
     """Cylinder aligned along Ox axis.
 
     Total number of panels = (2*resolution[0] + resolution[2])*resolution[1]
@@ -193,6 +220,10 @@ def mesh_horizontal_cylinder(*, length=10.0, radius=1.0, center=(0, 0, 0),
     resolution : 3-ple of int, optional
         (number of panel along a radius at the end, number of panels around a slice, number of slices)
         Mnemonic: same ordering as the cylindrical coordinates (nr, ntheta, nz)
+    faces_max_radius : float, optional
+        maximal radius of a panel. (Default: no maximal radius.)
+        If the provided resolution is too coarse, the number of panels is
+        changed to fit the constraint on the maximal radius.
     reflection_symmetry : bool, optional
         if True, returns a ReflectionSymmetricMesh
     translation_symmetry : bool, optional
@@ -218,6 +249,16 @@ def mesh_horizontal_cylinder(*, length=10.0, radius=1.0, center=(0, 0, 0),
     LOG.debug(f"New horizontal cylinder of length {length}, radius {radius} and resolution {resolution}, named {name}.")
 
     nr, ntheta, nx = resolution
+    if faces_max_radius is not None:
+        dr, dtheta, dx = radius/nr, 2*pi*radius/ntheta, length/nx
+        estimated_max_radius = max(
+                np.hypot(dr, dtheta)/2,  # Panel on disk side
+                np.hypot(dtheta, dx)/2,  # Panel on cylinder itself
+                )
+        if estimated_max_radius > faces_max_radius:
+            nr = int(np.ceil(radius / (np.sqrt(2) * faces_max_radius)))
+            ntheta = int(np.ceil(2*pi*radius / (np.sqrt(2) * faces_max_radius)))
+            nx = int(np.ceil(length / (np.sqrt(2) * faces_max_radius)))
 
     if reflection_symmetry:
         if ntheta % 2 == 1:

--- a/capytaine/meshes/predefined/cylinders.py
+++ b/capytaine/meshes/predefined/cylinders.py
@@ -16,7 +16,8 @@ from capytaine.meshes.symmetric import TranslationalSymmetricMesh, AxialSymmetri
 LOG = logging.getLogger(__name__)
 
 
-def mesh_disk(*, radius=1.0, center=(0, 0, 0), normal=(0, 0, 1), resolution=(3, 6),
+def mesh_disk(*, radius=1.0, center=(0, 0, 0), normal=(0, 0, 1),
+        resolution=(3, 6),
         reflection_symmetry=False, axial_symmetry=False, name=None, _theta_max=2*pi):
     """(One-sided) disk.
 

--- a/capytaine/meshes/predefined/rectangles.py
+++ b/capytaine/meshes/predefined/rectangles.py
@@ -106,9 +106,10 @@ def mesh_rectangle(*, size=(5.0, 5.0), center=(0.0, 0.0, 0.0),
     return mesh
 
 
-def mesh_parallelepiped(size=(1.0, 1.0, 1.0), resolution=(4, 4, 4), center=(0, 0, 0),
-             missing_sides=set(), reflection_symmetry=False, translation_symmetry=False,
-             name=None):
+def mesh_parallelepiped(size=(1.0, 1.0, 1.0), center=(0, 0, 0),
+                        resolution=(4, 4, 4), faces_max_radius=None,
+                        missing_sides=set(), reflection_symmetry=False, translation_symmetry=False,
+                        name=None):
     """Six rectangles forming a parallelepiped.
 
     Parameters

--- a/capytaine/meshes/predefined/rectangles.py
+++ b/capytaine/meshes/predefined/rectangles.py
@@ -57,7 +57,7 @@ def mesh_rectangle(*, size=(5.0, 5.0), center=(0.0, 0.0, 0.0),
     nw, nh = resolution
 
     if faces_max_radius is not None:
-        estimated_max_radius = np.sqrt(width/nw * height/nh * 1/2)
+        estimated_max_radius = np.hypot(width/nw, height/nh)/2
         if estimated_max_radius > faces_max_radius:
             nw = int(np.ceil(width / (np.sqrt(2) * faces_max_radius)))
             nh = int(np.ceil(height / (np.sqrt(2) * faces_max_radius)))
@@ -152,10 +152,11 @@ def mesh_parallelepiped(size=(1.0, 1.0, 1.0), center=(0, 0, 0),
     nw, nth, nh = resolution
 
     if faces_max_radius is not None:
+        dw, dh, dth = width/nw, height/nh, thickness/nth
         estimated_max_radius = max(
-                np.sqrt(width/nw * height/nh * 1/2),
-                np.sqrt(thickness/nth * height/nh * 1/2),
-                np.sqrt(width/nw * thickness/nth * 1/2),
+                np.hypot(dw, dh)/2,
+                np.hypot(dw, dth)/2,
+                np.hypot(dth, dh)/2,
                 )
         if estimated_max_radius > faces_max_radius:
             nw = int(np.ceil(width / (np.sqrt(2) * faces_max_radius)))

--- a/capytaine/meshes/predefined/rectangles.py
+++ b/capytaine/meshes/predefined/rectangles.py
@@ -1,5 +1,5 @@
 """Generate rectangular bodies."""
-# Copyright (C) 2017-2022 Matthieu Ancellin
+# Copyright (C) 2017-2024 Matthieu Ancellin
 # See LICENSE file at <https://github.com/capytaine/capytaine>
 import logging
 from itertools import product
@@ -13,7 +13,11 @@ from capytaine.meshes.collections import CollectionOfMeshes
 
 LOG = logging.getLogger(__name__)
 
-def mesh_rectangle(*, size=(5.0, 5.0), resolution=(5, 5), center=(0.0, 0.0, 0.0), normal=(0.0, 0.0, 1.0), translation_symmetry=False, reflection_symmetry=False, name=None):
+def mesh_rectangle(*, size=(5.0, 5.0), center=(0.0, 0.0, 0.0),
+        resolution=(5, 5), faces_max_radius=None,
+        normal=(0.0, 0.0, 1.0),
+        translation_symmetry=False, reflection_symmetry=False,
+        name=None):
     """One-sided rectangle.
 
     By default, the rectangle is horizontal, the normals are oriented upwards.
@@ -22,10 +26,14 @@ def mesh_rectangle(*, size=(5.0, 5.0), resolution=(5, 5), center=(0.0, 0.0, 0.0)
     ----------
     size : couple of floats, optional
         dimensions of the rectangle (width and height)
-    resolution : couple of ints, optional
-        number of faces along each of the two directions
     center : 3-ple of floats, optional
         position of the geometric center of the rectangle, default: (0, 0, 0)
+    resolution : couple of ints, optional
+        number of faces along each of the two directions
+    faces_max_radius : float, optional
+        maximal radius of a panel. (Default: no maximal radius.)
+        If the provided resolution is too coarse, the number of panels is
+        changed to fit the constraint on the maximal radius.
     normal: 3-ple of floats, optional
         normal vector, default: (0, 0, 1)
     translation_symmetry : bool, optional
@@ -47,6 +55,12 @@ def mesh_rectangle(*, size=(5.0, 5.0), resolution=(5, 5), center=(0.0, 0.0, 0.0)
 
     width, height = size
     nw, nh = resolution
+
+    if faces_max_radius is not None:
+        estimated_max_radius = np.sqrt(width/nw * height/nh * 1/2)
+        if estimated_max_radius > faces_max_radius:
+            nw = int(np.ceil(width / (np.sqrt(2) * faces_max_radius)))
+            nh = int(np.ceil(height / (np.sqrt(2) * faces_max_radius)))
 
     if name is None:
         name = f"rectangle_{next(Mesh._ids)}"
@@ -101,10 +115,14 @@ def mesh_parallelepiped(size=(1.0, 1.0, 1.0), resolution=(4, 4, 4), center=(0, 0
     ----------
     size : 3-ple of floats, optional
         dimensions of the parallelepiped (width, thickness, height) for coordinates (x, y, z).
-    resolution : 3-ple of ints, optional
-        number of faces along the three directions
     center : 3-ple of floats, optional
         coordinates of the geometric center of the parallelepiped
+    resolution : 3-ple of ints, optional
+        number of faces along the three directions
+    faces_max_radius : float, optional
+        maximal radius of a panel. (Default: no maximal radius.)
+        If the provided resolution is too coarse, the number of panels is
+        changed to fit the constraint on the maximal radius.
     missing_sides : set of string, optional
         if one of the keyword "top", "bottom", "front", "back", "left", "right" is in the set,
         then the corresponding side is not included in the parallelepiped.
@@ -131,6 +149,18 @@ def mesh_parallelepiped(size=(1.0, 1.0, 1.0), resolution=(4, 4, 4), center=(0, 0
 
     width, thickness, height = size
     nw, nth, nh = resolution
+
+    if faces_max_radius is not None:
+        estimated_max_radius = max(
+                np.sqrt(width/nw * height/nh * 1/2),
+                np.sqrt(thickness/nth * height/nh * 1/2),
+                np.sqrt(width/nw * thickness/nth * 1/2),
+                )
+        if estimated_max_radius > faces_max_radius:
+            nw = int(np.ceil(width / (np.sqrt(2) * faces_max_radius)))
+            nth = int(np.ceil(thickness / (np.sqrt(2) * faces_max_radius)))
+            nh = int(np.ceil(height / (np.sqrt(2) * faces_max_radius)))
+
     if name is None:
         name = f"rectangular_parallelepiped_{next(Mesh._ids)}"
 

--- a/capytaine/meshes/predefined/spheres.py
+++ b/capytaine/meshes/predefined/spheres.py
@@ -1,5 +1,5 @@
 """Generate spherical bodies."""
-# Copyright (C) 2017-2022 Matthieu Ancellin
+# Copyright (C) 2017-2024 Matthieu Ancellin
 # See LICENSE file at <https://github.com/capytaine/capytaine>
 import logging
 
@@ -13,7 +13,9 @@ from capytaine.meshes.symmetric import AxialSymmetricMesh
 LOG = logging.getLogger(__name__)
 
 
-def mesh_sphere(*, radius=1.0, center=(0.0, 0.0, 0.0), resolution=(10, 10), axial_symmetry=False, name=None):
+def mesh_sphere(*, radius=1.0, center=(0.0, 0.0, 0.0),
+        resolution=(10, 10), faces_max_radius=None,
+        axial_symmetry=False, name=None):
     """Sphere
 
     Parameters
@@ -23,7 +25,12 @@ def mesh_sphere(*, radius=1.0, center=(0.0, 0.0, 0.0), resolution=(10, 10), axia
     center : 3-ple or array of shape (3,)
         position of the geometric center of the sphere
     resolution : couple of ints
-        number of panels along a meridian (or number of parallels-1) and along a parallel (or number of meridians-1)
+        number of panels along a meridian (or number of parallels-1) and
+        along a parallel (or number of meridians-1)
+    faces_max_radius : float, optional
+        maximal radius of a panel. (Default: no maximal radius.)
+        If the provided resolution is too coarse, the number of panels is
+        changed to fit the constraint on the maximal radius.
     axial_symmetry : bool
         if True, use the axial symmetry to build the mesh (default: False)
     name : string
@@ -34,6 +41,11 @@ def mesh_sphere(*, radius=1.0, center=(0.0, 0.0, 0.0), resolution=(10, 10), axia
         name = f"sphere_{next(Mesh._ids)}"
 
     ntheta, nphi = resolution
+    if faces_max_radius is not None:
+        perimeter = 2*np.pi*radius
+        estimated_max_radius = perimeter / np.sqrt(2*ntheta*nphi)
+        if estimated_max_radius > faces_max_radius:
+            ntheta = nphi = int(np.ceil(perimeter / (np.sqrt(2)*faces_max_radius)))
 
     theta = np.linspace(0.0, pi, ntheta+1)
     points_on_a_meridian = radius * np.stack([np.sin(theta), np.zeros_like(theta), -np.cos(theta)], axis=1)
@@ -48,3 +60,4 @@ def mesh_sphere(*, radius=1.0, center=(0.0, 0.0, 0.0), resolution=(10, 10), axia
     mesh.translate(center)
     mesh.geometric_center = np.asarray(center, dtype=float)
     return mesh
+

--- a/capytaine/meshes/predefined/spheres.py
+++ b/capytaine/meshes/predefined/spheres.py
@@ -43,7 +43,7 @@ def mesh_sphere(*, radius=1.0, center=(0.0, 0.0, 0.0),
     ntheta, nphi = resolution
     if faces_max_radius is not None:
         perimeter = 2*np.pi*radius
-        estimated_max_radius = perimeter / np.sqrt(2*ntheta*nphi)
+        estimated_max_radius = np.hypot(perimeter/ntheta, perimeter/nphi)/2
         if estimated_max_radius > faces_max_radius:
             ntheta = nphi = int(np.ceil(perimeter / (np.sqrt(2)*faces_max_radius)))
 
@@ -60,4 +60,3 @@ def mesh_sphere(*, radius=1.0, center=(0.0, 0.0, 0.0),
     mesh.translate(center)
     mesh.geometric_center = np.asarray(center, dtype=float)
     return mesh
-

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -42,6 +42,8 @@ Minor changes
 
 * Rephrase mesh resolution warnings and group several of them together in a single warning. (:pull:`423`)
 
+* Add a `faces_max_radius` argument to the predefined geometries from :mod:`~cpt.meshes.predefined` to set up the resolution by giving a length scale for the panels (:pull:`459`).
+
 Bug fixes
 ~~~~~~~~~
 

--- a/pytest/test_meshes_predefined.py
+++ b/pytest/test_meshes_predefined.py
@@ -142,9 +142,9 @@ def test_mesh_sphere_axial_symmetry():
     assert isinstance(d, cpt.AxialSymmetricMesh)
     assert np.allclose(d.axis.vector, (0, 0, 1))
 
-def test_mesh_resolution_max_size():
+@pytest.mark.parametrize("max_rad", [0.5, 1.0, 5.0])
+def test_mesh_sphere_max_size(max_rad):
     from capytaine.meshes.predefined.spheres import mesh_sphere
-    max_rad = 0.1 + 2*np.random.rand()
     d = mesh_sphere(radius=10.0, faces_max_radius=max_rad)
     assert d.faces_radiuses.max() <= max_rad
     d = mesh_sphere(
@@ -176,9 +176,9 @@ def test_mesh_rectangle_both_symmetries():
     with pytest.raises(NotImplementedError):
         mesh_rectangle(translation_symmetry=True, reflection_symmetry=True)
 
-def test_mesh_rectangle_max_size():
+@pytest.mark.parametrize("max_rad", [0.5, 1.0, 5.0])
+def test_mesh_rectangle_max_size(max_rad):
     from capytaine.meshes.predefined.rectangles import mesh_rectangle
-    max_rad = 0.01 + np.random.rand()
     d = mesh_rectangle(size=(10.0, 10.0), faces_max_radius=max_rad)
     assert d.faces_radiuses.max() <= max_rad
 
@@ -218,9 +218,9 @@ def test_mesh_parallelepiped_translation_symmetry():
     assert isinstance(p[0], cpt.TranslationalSymmetricMesh)
     assert p.nb_faces == 6*16
 
-def test_mesh_parallelepiped_max_size():
+@pytest.mark.parametrize("max_rad", [0.5, 1.0, 5.0])
+def test_mesh_parallelepiped_max_size(max_rad):
     from capytaine.meshes.predefined.rectangles import mesh_parallelepiped
-    max_rad = 0.01 + np.random.rand()
     d = mesh_parallelepiped(size=(10.0, 10.0, 10.0), faces_max_radius=max_rad)
     assert d.faces_radiuses.max() <= max_rad
     d = mesh_parallelepiped(size=(1.0, 10.0, 1.0), faces_max_radius=max_rad)

--- a/pytest/test_meshes_predefined.py
+++ b/pytest/test_meshes_predefined.py
@@ -142,6 +142,16 @@ def test_mesh_sphere_axial_symmetry():
     assert isinstance(d, cpt.AxialSymmetricMesh)
     assert np.allclose(d.axis.vector, (0, 0, 1))
 
+def test_mesh_resolution_max_size():
+    from capytaine.meshes.predefined.spheres import mesh_sphere
+    max_rad = 0.1 + 2*np.random.rand()
+    d = mesh_sphere(radius=10.0, faces_max_radius=max_rad)
+    assert d.faces_radiuses.max() <= max_rad
+    d = mesh_sphere(
+            radius=10.0, resolution=(10, 10),
+            faces_max_radius=max_rad)
+    assert 2*np.pi < d.faces_radiuses.max() <= max_rad
+
 # RECTANGLES
 
 def test_mesh_rectangle():
@@ -165,6 +175,12 @@ def test_mesh_rectangle_both_symmetries():
     from capytaine.meshes.predefined.rectangles import mesh_rectangle
     with pytest.raises(NotImplementedError):
         mesh_rectangle(translation_symmetry=True, reflection_symmetry=True)
+
+def test_mesh_rectangle_max_size():
+    from capytaine.meshes.predefined.rectangles import mesh_rectangle
+    max_rad = 0.01 + np.random.rand()
+    d = mesh_rectangle(size=(10.0, 10.0), faces_max_radius=max_rad)
+    assert d.faces_radiuses.max() <= max_rad
 
 # PARALLELEPIPED
 
@@ -201,3 +217,11 @@ def test_mesh_parallelepiped_translation_symmetry():
     assert isinstance(p, cpt.CollectionOfMeshes)
     assert isinstance(p[0], cpt.TranslationalSymmetricMesh)
     assert p.nb_faces == 6*16
+
+def test_mesh_parallelepiped_max_size():
+    from capytaine.meshes.predefined.rectangles import mesh_parallelepiped
+    max_rad = 0.01 + np.random.rand()
+    d = mesh_parallelepiped(size=(10.0, 10.0, 10.0), faces_max_radius=max_rad)
+    assert d.faces_radiuses.max() <= max_rad
+    d = mesh_parallelepiped(size=(1.0, 10.0, 1.0), faces_max_radius=max_rad)
+    assert d.faces_radiuses.max() <= max_rad

--- a/pytest/test_meshes_predefined.py
+++ b/pytest/test_meshes_predefined.py
@@ -150,7 +150,7 @@ def test_mesh_resolution_max_size():
     d = mesh_sphere(
             radius=10.0, resolution=(10, 10),
             faces_max_radius=max_rad)
-    assert 2*np.pi < d.faces_radiuses.max() <= max_rad
+    assert d.faces_radiuses.max() <= max_rad
 
 # RECTANGLES
 

--- a/pytest/test_meshes_predefined.py
+++ b/pytest/test_meshes_predefined.py
@@ -41,7 +41,6 @@ def test_mesh_disk_both_symmetries():
 def test_mesh_disk_max_size(max_rad):
     from capytaine.meshes.predefined.cylinders import mesh_disk
     d = mesh_disk(radius=10.0, faces_max_radius=max_rad)
-    d.show()
     assert d.faces_radiuses.max() <= max_rad
 
 # VERTICAL CYLINDER

--- a/pytest/test_meshes_predefined.py
+++ b/pytest/test_meshes_predefined.py
@@ -146,6 +146,7 @@ def test_mesh_sphere_axial_symmetry():
 def test_mesh_sphere_max_size(max_rad):
     from capytaine.meshes.predefined.spheres import mesh_sphere
     d = mesh_sphere(radius=10.0, faces_max_radius=max_rad)
+    print(d.faces_radiuses.max())
     assert d.faces_radiuses.max() <= max_rad
     d = mesh_sphere(
             radius=10.0, resolution=(10, 10),

--- a/pytest/test_meshes_predefined.py
+++ b/pytest/test_meshes_predefined.py
@@ -37,6 +37,12 @@ def test_mesh_disk_both_symmetries():
     with pytest.raises(NotImplementedError):
         mesh_disk(axial_symmetry=True, reflection_symmetry=True)
 
+@pytest.mark.parametrize("max_rad", [0.5, 1.0, 5.0])
+def test_mesh_disk_max_size(max_rad):
+    from capytaine.meshes.predefined.cylinders import mesh_disk
+    d = mesh_disk(radius=10.0, faces_max_radius=max_rad)
+    d.show()
+    assert d.faces_radiuses.max() <= max_rad
 
 # VERTICAL CYLINDER
 
@@ -71,6 +77,11 @@ def test_mesh_vertical_cylinder_both_symmetries():
     with pytest.raises(NotImplementedError):
         mesh_vertical_cylinder(axial_symmetry=True, reflection_symmetry=True)
 
+@pytest.mark.parametrize("max_rad", [0.5, 1.0, 5.0])
+def test_mesh_vertical_max_size(max_rad):
+    from capytaine.meshes.predefined.cylinders import mesh_vertical_cylinder
+    d = mesh_vertical_cylinder(radius=10.0, faces_max_radius=max_rad)
+    assert d.faces_radiuses.max() <= max_rad
 
 # HORIZONTAL CYLINDER
 
@@ -119,6 +130,12 @@ def test_mesh_horizontal_both_symmetries():
     assert isinstance(h[0][0], cpt.TranslationalSymmetricMesh)
     assert isinstance(h[0][1], cpt.Mesh)
 
+@pytest.mark.parametrize("max_rad", [0.5, 1.0, 5.0])
+def test_mesh_horizontal_max_size(max_rad):
+    from capytaine.meshes.predefined.cylinders import mesh_horizontal_cylinder
+    d = mesh_horizontal_cylinder(radius=10.0, faces_max_radius=max_rad)
+    assert d.faces_radiuses.max() <= max_rad
+
 # SPHERE
 
 def test_mesh_sphere():
@@ -146,7 +163,6 @@ def test_mesh_sphere_axial_symmetry():
 def test_mesh_sphere_max_size(max_rad):
     from capytaine.meshes.predefined.spheres import mesh_sphere
     d = mesh_sphere(radius=10.0, faces_max_radius=max_rad)
-    print(d.faces_radiuses.max())
     assert d.faces_radiuses.max() <= max_rad
     d = mesh_sphere(
             radius=10.0, resolution=(10, 10),


### PR DESCRIPTION
Introduces a `faces_max_radius` parameter to the mesh generation functions to adjust the size of the panels in the mesh.

- [x] sphere
- [x] rectangles
- [x] parallelepiped
- [x] cylinder
- [x] disks