### PR TITLE
Fix bug with manually defined center as tuple.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -64,6 +64,8 @@ Bug fixes
 
 * The function :func:`~capytaine.io.meshes_loaders.load_mesh` more robustly detects filetype using file extension even when the file extension is not lowercase. (:pull:`441`)
 
+* Fix bug with bodies translation or rotation when the rotation center or the center of mass had been defined as list or tuples instead of array (:pull:`472`).
+
 Internals
 ~~~~~~~~~
 

--- a/pytest/test_bodies.py
+++ b/pytest/test_bodies.py
@@ -122,6 +122,27 @@ def test_bodies():
     both = body.join_bodies(copy_of_body)
     assert set(both.dofs) == {'sphere__Surge', 'copy_of_sphere__Surge', 'sphere__Heave', 'copy_of_sphere__Heave'}
 
+def test_mirror_rotation_center_defined_as_tuple():
+    body = cpt.FloatingBody()
+    body.rotation_center = (0, 1, 0)
+    body.mirror(cpt.xOz_Plane)
+    assert body.rotation_center.shape == (3,)
+    np.testing.assert_allclose(body.rotation_center, np.array([0, -1, 0]))
+
+def test_translate_rotation_center_defined_as_tuple():
+    body = cpt.FloatingBody()
+    body.rotation_center = (0, 0, 0)
+    body.translate((0, 0, 1))
+    assert body.rotation_center.shape == (3,)
+    np.testing.assert_allclose(body.rotation_center, np.array([0, 0, 1]))
+
+def test_rotate_rotation_center_defined_as_tuple():
+    body = cpt.FloatingBody()
+    body.rotation_center = (1, 0, 0)
+    body.rotate_z(np.pi)
+    assert body.rotation_center.shape == (3,)
+    np.testing.assert_allclose(body.rotation_center, np.array([-1, 0, 0]), atol=1e-10)
+
 
 @pytest.mark.parametrize("z_center", [0, 2, -2])
 @pytest.mark.parametrize("as_collection_of_meshes", [True, False])


### PR DESCRIPTION
Namely, when the rotation_center or the center_of_mass are manually defined as something else than a vector. It was a poor design decision to support in early version of Capytaine, but now I'll try to keep it working, even if I don't recommend it.