### PR TITLE
Tabulation parameters: default values and display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,6 @@ clean:
 	rm -rf .nox/
 	rm -rf .venv/
 	rm -rf __pycache__ */__pycache__ */*/__pycache__ */*/*/__pycache__
+	rm -rf ${HOME}/.cache/capytaine/*
 
 .PHONY: install develop test clean test_fortran_compilation

--- a/capytaine/green_functions/delhommeau.py
+++ b/capytaine/green_functions/delhommeau.py
@@ -44,7 +44,7 @@ class Delhommeau(AbstractGreenFunction):
         Only used with the :code:`"scaled_nemoh3"` method.
         Default: 100.0
     tabulation_nz: int, optional
-        Number of tabulation points for vertical distance.
+        Number of tabulation points for vertical coordinate.
         If 0 is given, no tabulation is used at all.
         Default: 372
     tabulation_zmin: float, optional

--- a/pytest/test_airy_waves.py
+++ b/pytest/test_airy_waves.py
@@ -1,0 +1,19 @@
+import pytest
+
+import numpy as np
+import capytaine as cpt
+from capytaine.bem.airy_waves import froude_krylov_force
+
+
+def test_Froude_Krylov():
+    sphere = cpt.FloatingBody(cpt.mesh_sphere(radius=1.0, resolution=(6, 12)).immersed_part())
+    sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
+
+    problem = cpt.DiffractionProblem(body=sphere, omega=1.0, water_depth=np.inf)
+    assert np.isclose(froude_krylov_force(problem)['Heave'], 27596, rtol=1e-3)
+
+    problem = cpt.DiffractionProblem(body=sphere, omega=2.0, water_depth=np.inf)
+    assert np.isclose(froude_krylov_force(problem)['Heave'], 22491, rtol=1e-3)
+
+    problem = cpt.DiffractionProblem(body=sphere, omega=1.0, water_depth=10.0)
+    assert np.isclose(froude_krylov_force(problem)['Heave'], 27610, rtol=1e-3)

--- a/pytest/test_bem_linear_combination_of_dofs.py
+++ b/pytest/test_bem_linear_combination_of_dofs.py
@@ -1,13 +1,8 @@
-#!/usr/bin/env python
-# coding: utf-8
-
 import numpy as np
 import capytaine as cpt
 import pytest
 
-solver = cpt.BEMSolver()
 method = ['indirect', 'direct']
-
 
 @pytest.mark.parametrize("method", method)
 def test_sum_of_dofs(method):
@@ -21,6 +16,7 @@ def test_sum_of_dofs(method):
     both.add_translation_dof(name="Heave")
 
     problems = [cpt.RadiationProblem(body=both, radiating_dof=dof, omega=1.0) for dof in both.dofs]
+    solver = cpt.BEMSolver()
     results = solver.solve_all(problems, method=method)
     dataset = cpt.assemble_dataset(results)
 
@@ -43,6 +39,7 @@ def test_rotation_axis(method):
     assert np.allclose(body.dofs['other_rotation'], (body.dofs['Yaw'] - l*body.dofs['Sway']))
 
     problems = [cpt.RadiationProblem(body=body, radiating_dof=dof, omega=1.0) for dof in body.dofs]
+    solver = cpt.BEMSolver()
     results = solver.solve_all(problems, keep_details=True, method=method)
     dataset = cpt.assemble_dataset(results)
 

--- a/pytest/test_bem_problems_and_results.py
+++ b/pytest/test_bem_problems_and_results.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# coding: utf-8
-
 import os
 import logging
 
@@ -11,23 +8,26 @@ import xarray as xr
 
 import capytaine as cpt
 
-from capytaine.meshes.meshes import Mesh
-from capytaine.meshes.symmetric import ReflectionSymmetricMesh
-
-from capytaine.bodies import FloatingBody
-from capytaine.bodies.predefined.spheres import Sphere
-from capytaine.bodies.predefined.cylinders import HorizontalCylinder
-
-from capytaine.bem.problems_and_results import LinearPotentialFlowProblem, DiffractionProblem, RadiationProblem, \
-    LinearPotentialFlowResult, DiffractionResult, RadiationResult
+from capytaine.bem.problems_and_results import LinearPotentialFlowProblem, \
+        LinearPotentialFlowResult, DiffractionResult, RadiationResult
 from capytaine.io.xarray import problems_from_dataset, assemble_dataset
-
 from capytaine.io.legacy import import_cal_file
 
-solver = cpt.BEMSolver()
-method = ['indirect','direct']
 
-def test_LinearPotentialFlowProblem():
+@pytest.fixture
+def sphere():
+    sphere = cpt.FloatingBody(cpt.mesh_sphere(center=(0, 0, -2), radius=1.0, ntheta=20, nphi=40))
+    sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
+    return sphere
+
+
+@pytest.fixture
+def solver():
+    solver = cpt.BEMSolver()
+    return solver
+
+
+def test_LinearPotentialFlowProblem(sphere):
     # Without a body
     pb = LinearPotentialFlowProblem(omega=1.0)
     assert pb.omega == 1.0
@@ -55,11 +55,9 @@ def test_LinearPotentialFlowProblem():
         LinearPotentialFlowProblem(radiating_dof="Heave")
 
     with pytest.raises(ValueError):
-        LinearPotentialFlowProblem(body=FloatingBody(mesh=Mesh([], [])))
+        LinearPotentialFlowProblem(body=cpt.FloatingBody(mesh=cpt.Mesh([], [])))
 
     # With a body
-    sphere = Sphere(center=(0, 0, -2.0))
-    sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
     pb = LinearPotentialFlowProblem(body=sphere, omega=1.0)
     pb.boundary_condition = sphere.mesh.faces_normals @ (1, 1, 1)
     assert list(pb.influenced_dofs.keys()) == ['Heave']
@@ -76,74 +74,67 @@ def test_LinearPotentialFlowProblem():
     assert res.period == pb.period
     assert res.body is pb.body
 
+
 def test_backward_compatibility_with_sea_bottom_argument(caplog):
     with caplog.at_level(logging.WARNING):
         pb = cpt.DiffractionProblem(sea_bottom=-10.0)
         assert pb.water_depth == 10.0
     assert 'water_depth' in caplog.text
 
+
 @pytest.mark.parametrize("water_depth", [10.0, np.inf])
 def test_setting_wavelength(water_depth):
     λ = 10*np.random.rand()
     assert np.isclose(cpt.DiffractionProblem(wavelength=λ, water_depth=water_depth).wavelength, λ)
+
 
 @pytest.mark.parametrize("water_depth", [10.0, np.inf])
 def test_setting_wavenumber(water_depth):
     k = 10*np.random.rand()
     assert np.isclose(cpt.DiffractionProblem(wavenumber=k, water_depth=water_depth).wavenumber, k)
 
+
 @pytest.mark.parametrize("water_depth", [10.0, np.inf])
 def test_setting_period(water_depth):
     T = 10*np.random.rand()
     assert np.isclose(cpt.DiffractionProblem(period=T, water_depth=water_depth).period, T)
+
 
 def test_setting_too_many_frequencies():
     with pytest.raises(ValueError, match="at most one"):
         cpt.DiffractionProblem(omega=1.0, wavelength=1.0)
 
 
-def test_diffraction_problem():
-    assert DiffractionProblem(omega=1.0).body is None
+def test_diffraction_problem(sphere):
+    assert cpt.DiffractionProblem(omega=1.0).body is None
 
-    sphere = Sphere(radius=1.0, ntheta=20, nphi=40)
-    sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
-
-    pb = DiffractionProblem(body=sphere, wave_direction=1.0, wavenumber=1.0)
+    pb = cpt.DiffractionProblem(body=sphere, wave_direction=1.0, wavenumber=1.0)
     assert len(pb.boundary_condition) == sphere.mesh.nb_faces
 
     with pytest.raises(TypeError):
-        DiffractionProblem(boundary_conditions=[0, 0, 0])
+        cpt.DiffractionProblem(boundary_conditions=[0, 0, 0])
 
-    assert "DiffractionProblem" in str(DiffractionProblem(wavenumber=1.0, g=10, rho=1025, free_surface=np.inf))
+    assert "DiffractionProblem" in str(cpt.DiffractionProblem(wavenumber=1.0, g=10, rho=1025, free_surface=np.inf))
 
     res = pb.make_results_container()
     assert isinstance(res, DiffractionResult)
 
 
-def test_wave_direction_radians_warning(caplog):
-    sphere = Sphere(radius=1.0, ntheta=20, nphi=40)
-    sphere.keep_immersed_part()
-    sphere.add_all_rigid_body_dofs()
+def test_wave_direction_radians_warning(sphere, caplog):
     with caplog.at_level(logging.WARNING):
-        DiffractionProblem(body=sphere, omega=1.0, wave_direction=180)
+        cpt.DiffractionProblem(body=sphere, omega=1.0, wave_direction=180)
     assert 'in radians and not in degrees' in caplog.text
 
 
-def test_radiation_problem(caplog):
-    sphere = Sphere(radius=1.0, ntheta=20, nphi=40, clip_free_surface=True)
-
-    # with pytest.raises(ValueError):
-    #     RadiationProblem(body=sphere)
-
-    sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
-    pb = RadiationProblem(body=sphere, omega=1.0)
+def test_radiation_problem(sphere, caplog):
+    pb = cpt.RadiationProblem(body=sphere, omega=1.0)
     assert len(pb.boundary_condition) == sphere.mesh.nb_faces
 
     sphere.add_translation_dof(direction=(1, 0, 0), name="Surge")
-    pb2 = RadiationProblem(body=sphere, radiating_dof="Heave")
+    pb2 = cpt.RadiationProblem(body=sphere, radiating_dof="Heave")
     assert np.all(pb.boundary_condition == pb2.boundary_condition)
 
-    assert "RadiationProblem" in str(RadiationProblem(g=10, rho=1025, free_surface=np.inf))
+    assert "RadiationProblem" in str(cpt.RadiationProblem(g=10, rho=1025, free_surface=np.inf))
 
     res = pb.make_results_container()
     assert isinstance(res, RadiationResult)
@@ -155,21 +146,16 @@ def test_radiation_problem(caplog):
     assert res.radiation_damping == res.radiation_dampings == {"Heave": 2.0}
 
 
-def test_Froude_Krylov():
+def test_Froude_Krylov(sphere):
     from capytaine.bem.airy_waves import froude_krylov_force
-    from capytaine.bodies.predefined.spheres import Sphere
-    from capytaine.bem.problems_and_results import DiffractionProblem
 
-    sphere = Sphere(radius=1.0, ntheta=3, nphi=12, clever=True, clip_free_surface=True)
-    sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
-
-    problem = DiffractionProblem(body=sphere, omega=1.0, water_depth=np.inf)
+    problem = cpt.DiffractionProblem(body=sphere, omega=1.0, water_depth=np.inf)
     assert np.isclose(froude_krylov_force(problem)['Heave'], 27596, rtol=1e-3)
 
-    problem = DiffractionProblem(body=sphere, omega=2.0, water_depth=np.inf)
+    problem = cpt.DiffractionProblem(body=sphere, omega=2.0, water_depth=np.inf)
     assert np.isclose(froude_krylov_force(problem)['Heave'], 22491, rtol=1e-3)
 
-    problem = DiffractionProblem(body=sphere, omega=1.0, water_depth=10.0)
+    problem = cpt.DiffractionProblem(body=sphere, omega=1.0, water_depth=10.0)
     assert np.isclose(froude_krylov_force(problem)['Heave'], 27610, rtol=1e-3)
 
 
@@ -187,12 +173,12 @@ def test_import_cal_file(cal_file):
         assert problem.rho == 1000.0
         assert problem.g == 9.81
         assert problem.water_depth == np.inf
-        assert isinstance(problem.body, FloatingBody)
+        assert isinstance(problem.body, cpt.FloatingBody)
         assert problem.body.nb_dofs == 6
         assert problem.body.mesh.nb_vertices == 299  # Duplicate vertices are removed during import.
         assert problem.body.mesh.nb_faces == 280
         assert problem.omega in np.linspace(0.1, 2.0, 41)
-        if isinstance(problem, DiffractionProblem):
+        if isinstance(problem, cpt.DiffractionProblem):
             assert problem.wave_direction == 0.0
 
     # Symmetrical cylinder
@@ -204,34 +190,31 @@ def test_import_cal_file(cal_file):
         assert problem.rho == 1000.0
         assert problem.g == 9.81
         assert problem.water_depth == np.inf
-        assert isinstance(problem.body.mesh, ReflectionSymmetricMesh)
-        assert isinstance(problem.body.mesh[0], Mesh)
+        assert isinstance(problem.body.mesh, cpt.ReflectionSymmetricMesh)
+        assert isinstance(problem.body.mesh[0], cpt.Mesh)
         assert problem.body.nb_dofs == 6
         # assert problem.body.mesh.nb_vertices == 2*540
         assert problem.body.mesh.nb_faces == 2*300
         assert problem.omega == 0.1 or problem.omega == 2.0
-        if isinstance(problem, DiffractionProblem):
+        if isinstance(problem, cpt.DiffractionProblem):
             assert problem.wave_direction == 0.0
 
 
 def test_results():
     assert isinstance(LinearPotentialFlowProblem().make_results_container(), LinearPotentialFlowResult)
 
-    pb = DiffractionProblem(g=10, rho=1023, free_surface=np.inf)
+    pb = cpt.DiffractionProblem(g=10, rho=1023, free_surface=np.inf)
     res = DiffractionResult(pb)
     assert res.g == pb.g == 10
     assert "DiffractionResult" in str(res)
 
-    pb = RadiationProblem(g=10, rho=1023, free_surface=np.inf)
+    pb = cpt.RadiationProblem(g=10, rho=1023, free_surface=np.inf)
     res = RadiationResult(pb)
     assert res.g == pb.g == 10
     assert "RadiationResult" in str(res)
 
 
-def test_problems_from_dataset():
-    body = Sphere(center=(0, 0, -4), name="sphere")
-    body.add_translation_dof(name="Heave")
-
+def test_problems_from_dataset(sphere):
     dset = xr.Dataset(coords={'omega': [0.5, 1.0, 1.5],
                               'radiating_dof': ["Heave"],
                               'body_name': ["sphere"],
@@ -239,9 +222,9 @@ def test_problems_from_dataset():
                               'water_depth': [np.inf]})
 
     problems = problems_from_dataset(dset, [body])
-    assert RadiationProblem(body=body, omega=0.5, radiating_dof="Heave") in problems
+    assert cpt.RadiationProblem(body=body, omega=0.5, radiating_dof="Heave") in problems
     assert len(problems) == 6
-    assert len([problem for problem in problems if isinstance(problem, DiffractionProblem)]) == 3
+    assert len([problem for problem in problems if isinstance(problem, cpt.DiffractionProblem)]) == 3
 
     dset = xr.Dataset(coords={'omega': [0.5, 1.0, 1.5],
                               'wave_direction': [0.0],
@@ -254,39 +237,32 @@ def test_problems_from_dataset():
                               'radiating_dof': ["Heave"],
                               'wave_direction': [0.0]})
     problems = problems_from_dataset(dset, [body, shifted_body])
-    assert RadiationProblem(body=body, omega=0.5, radiating_dof="Heave") in problems
-    assert RadiationProblem(body=shifted_body, omega=0.5, radiating_dof="Heave") in problems
+    assert cpt.RadiationProblem(body=body, omega=0.5, radiating_dof="Heave") in problems
+    assert cpt.RadiationProblem(body=shifted_body, omega=0.5, radiating_dof="Heave") in problems
     assert len(problems) == 12
 
 
-def test_problems_from_dataset_with_wavelength():
-    body = cpt.FloatingBody(mesh=cpt.mesh_sphere(center=(0, 0, -4), name="sphere"),
-                            dofs=cpt.rigid_body_dofs(rotation_center=(0, 0, -4)))
+def test_problems_from_dataset_with_wavelength(sphere):
     dset = xr.Dataset(coords={'wavelength': [12.0], 'radiating_dof': ["Heave"]})
     problems = problems_from_dataset(dset, body)
     for pb in problems:
         assert np.isclose(pb.wavelength, 12.0)
 
 
-def test_problems_from_dataset_with_too_many_info():
-    body = cpt.FloatingBody(mesh=cpt.mesh_sphere(center=(0, 0, -4), name="sphere"),
-                            dofs=cpt.rigid_body_dofs(rotation_center=(0, 0, -4)))
+def test_problems_from_dataset_with_too_many_info(sphere):
     dset = xr.Dataset(coords={'wavelength': [12.0], 'period': [3.0], 'radiating_dof': ["Heave"]})
     with pytest.raises(ValueError, match="at most one"):
         problems = problems_from_dataset(dset, body)
 
 
-@pytest.mark.parametrize("method", method)
-def test_assemble_dataset(method):
-    body = Sphere(center=(0, 0, -4), name="sphere")
-    body.add_translation_dof(name="Heave")
-
-    pb_1 = DiffractionProblem(body=body, wave_direction=1.0, omega=1.0)
+@pytest.mark.parametrize("method", ['indirect','direct'])
+def test_assemble_dataset(sphere, solver, method):
+    pb_1 = cpt.DiffractionProblem(body=body, wave_direction=1.0, omega=1.0)
     res_1 = solver.solve(pb_1, method=method)
     ds1 = assemble_dataset([res_1])
     assert "Froude_Krylov_force" in ds1
 
-    pb_2 = RadiationProblem(body=body, radiating_dof="Heave", omega=1.0)
+    pb_2 = cpt.RadiationProblem(body=body, radiating_dof="Heave", omega=1.0)
     res_2 = solver.solve(pb_2, method=method)
     ds2 = assemble_dataset([res_2])
     assert "added_mass" in ds2
@@ -296,18 +272,14 @@ def test_assemble_dataset(method):
     assert "added_mass" in ds12
 
 
-def test_fill_dataset():
-    body = HorizontalCylinder(radius=1, center=(0, 0, -2))
-    body.add_all_rigid_body_dofs()
+def test_fill_dataset(sphere, solver):
     test_matrix = xr.Dataset(coords={'omega': [1.0, 2.0, 3.0], 'wave_direction': [0, np.pi/2], 'radiating_dof': ['Heave']})
     dataset = solver.fill_dataset(test_matrix, [body])
     assert dataset['added_mass'].data.shape == (3, 1, 6)
     assert dataset['Froude_Krylov_force'].data.shape == (3, 2, 6)
 
 
-def test_fill_dataset_with_wavenumbers():
-    body = cpt.FloatingBody(mesh=cpt.mesh_horizontal_cylinder(radius=1, center=(0, 0, -2)),
-                            dofs=cpt.rigid_body_dofs(rotation_center=(0, 0, -2)))
+def test_fill_dataset_with_wavenumbers(sphere, solver):
     k_range = np.linspace(1.0, 3.0, 3)
     test_matrix = xr.Dataset(coords={'wavenumber': k_range, 'wave_direction': [0, np.pi/2], 'radiating_dof': ['Heave']})
     dataset = solver.fill_dataset(test_matrix, [body])
@@ -319,9 +291,7 @@ def test_fill_dataset_with_wavenumbers():
     assert set(dataset.period.dims)     == {'wavenumber'}
 
 
-def test_fill_dataset_with_periods():
-    body = cpt.FloatingBody(mesh=cpt.mesh_horizontal_cylinder(radius=1, center=(0, 0, -2)),
-                            dofs=cpt.rigid_body_dofs(rotation_center=(0, 0, -2)))
+def test_fill_dataset_with_periods(sphere, solver):
     T_range = np.linspace(1.0, 3.0, 3)
     test_matrix = xr.Dataset(coords={'period': T_range, 'wave_direction': [0, np.pi/2], 'radiating_dof': ['Heave']})
     dataset = solver.fill_dataset(test_matrix, [body])
@@ -334,9 +304,7 @@ def test_fill_dataset_with_periods():
     assert set(dataset.period.dims)     == {'period'}
 
 
-def test_fill_dataset_with_wavenumbers_and_several_water_depths():
-    body = cpt.FloatingBody(mesh=cpt.mesh_horizontal_cylinder(radius=1, center=(0, 0, -2)),
-                            dofs=cpt.rigid_body_dofs(rotation_center=(0, 0, -2)))
+def test_fill_dataset_with_wavenumbers_and_several_water_depths(sphere, solver):
     k_range = np.linspace(1.0, 3.0, 3)
     test_matrix = xr.Dataset(coords={
         'wavenumber': k_range, 'radiating_dof': ['Heave'], 'water_depth': [4.0, 6.0],

--- a/pytest/test_bem_solver.py
+++ b/pytest/test_bem_solver.py
@@ -2,20 +2,10 @@ import pytest
 
 import numpy as np
 import xarray as xr
-from numpy import pi
-
-try:
-    import joblib
-except ImportError:
-    joblib = None
 
 import capytaine as cpt
 from capytaine import __version__
-from capytaine.bem.solver import BEMSolver
-from capytaine.green_functions.delhommeau import Delhommeau, XieDelhommeau
-from capytaine.bem.engines import BasicMatrixEngine
-from capytaine.bem.problems_and_results import RadiationProblem
-from capytaine.bodies.predefined.spheres import Sphere
+
 #-----------------------------------------------------------------------------#
 # Test indirect solver
 #-----------------------------------------------------------------------------#
@@ -28,20 +18,22 @@ def sphere():
 
 
 def test_exportable_settings():
-    gf = Delhommeau(tabulation_nb_integration_points=50)
+    gf = cpt.Delhommeau(tabulation_nr=10, tabulation_nz=10,
+                    tabulation_method="legacy", tabulation_nb_integration_points=50)
     assert gf.exportable_settings['green_function'] == 'Delhommeau'
     assert gf.exportable_settings['tabulation_nb_integration_points'] == 50
+    assert gf.exportable_settings['tabulation_method'] == "legacy"
     assert gf.exportable_settings['finite_depth_prony_decomposition_method'] == 'fortran'
 
-    gf2 = XieDelhommeau()
+    gf2 = cpt.XieDelhommeau()
     assert gf2.exportable_settings['green_function'] == 'XieDelhommeau'
 
-    engine = BasicMatrixEngine(matrix_cache_size=0)
+    engine = cpt.BasicMatrixEngine(matrix_cache_size=0)
     assert engine.exportable_settings['engine'] == 'BasicMatrixEngine'
     assert engine.exportable_settings['matrix_cache_size'] == 0
     assert engine.exportable_settings['linear_solver'] == 'lu_decomposition'
 
-    solver = BEMSolver(green_function=gf, engine=engine)
+    solver = cpt.BEMSolver(green_function=gf, engine=engine)
     assert solver.exportable_settings['green_function'] == 'Delhommeau'
     assert solver.exportable_settings['tabulation_nb_integration_points'] == 50
     assert solver.exportable_settings['finite_depth_prony_decomposition_method'] == 'fortran'
@@ -52,17 +44,17 @@ def test_exportable_settings():
 
 def test_limit_frequencies(sphere):
     """Test if how the solver answers when asked for frequency of 0 or ∞."""
-    solver = BEMSolver()
+    solver = cpt.BEMSolver()
 
-    solver.solve(RadiationProblem(body=sphere, omega=0.0, water_depth=np.inf))
-
-    with pytest.raises(NotImplementedError):
-        solver.solve(RadiationProblem(body=sphere, omega=0.0, water_depth=1.0))
-
-    solver.solve(RadiationProblem(body=sphere, omega=np.inf, water_depth=np.inf))
+    solver.solve(cpt.RadiationProblem(body=sphere, omega=0.0, water_depth=np.inf))
 
     with pytest.raises(NotImplementedError):
-        solver.solve(RadiationProblem(body=sphere, omega=np.inf, water_depth=10))
+        solver.solve(cpt.RadiationProblem(body=sphere, omega=0.0, water_depth=1.0))
+
+    solver.solve(cpt.RadiationProblem(body=sphere, omega=np.inf, water_depth=np.inf))
+
+    with pytest.raises(NotImplementedError):
+        solver.solve(cpt.RadiationProblem(body=sphere, omega=np.inf, water_depth=10))
 
 
 def test_limit_frequencies_with_symmetries():
@@ -75,8 +67,8 @@ def test_limit_frequencies_with_symmetries():
     assert isinstance(res.added_mass['Surge'], float)
 
 
-@pytest.mark.skipif(joblib is None, reason='joblib is not installed')
 def test_parallelization(sphere):
+    joblib = pytest.importorskip("joblib")
     solver = cpt.BEMSolver()
     test_matrix = xr.Dataset(coords={
         'omega': np.linspace(0.1, 4.0, 3),
@@ -92,10 +84,10 @@ def test_float32_solver(sphere):
 
 
 def test_fill_dataset(sphere):
-    solver = BEMSolver()
+    solver = cpt.BEMSolver()
     test_matrix = xr.Dataset(coords={
         'omega': np.linspace(0.1, 4.0, 3),
-        'wave_direction': np.linspace(0.0, pi, 3),
+        'wave_direction': np.linspace(0.0, np.pi, 3),
         'radiating_dof': list(sphere.dofs.keys()),
         'rho': [1025.0],
         'water_depth': [np.inf, 10.0],

--- a/pytest/test_consistency_with_Nemoh_2.py
+++ b/pytest/test_consistency_with_Nemoh_2.py
@@ -14,8 +14,8 @@ from capytaine.green_functions.delhommeau import Delhommeau
 from capytaine.io.xarray import assemble_dataset
 from capytaine.post_pro.kochin import compute_kochin
 
-gf = Delhommeau(tabulation_nr=328, tabulation_nz=46, tabulation_method='legacy')
-solver = cpt.BEMSolver(engine=cpt.BasicMatrixEngine(matrix_cache_size=0),green_function=gf)
+gf = Delhommeau(tabulation_nr=328, tabulation_nz=46, tabulation_method='legacy', tabulation_nb_integration_points=251)
+solver = cpt.BEMSolver(engine=cpt.BasicMatrixEngine(matrix_cache_size=0), green_function=gf)
 
 
 def test_immersed_sphere():

--- a/pytest/test_consistency_with_Nemoh_2.py
+++ b/pytest/test_consistency_with_Nemoh_2.py
@@ -48,8 +48,8 @@ def test_immersed_sphere(nemoh2_solver):
     assert np.isclose(result.radiation_dampings["Heave"],  0.0, atol=1e-3*sphere.volume*problem.rho)
 
 
-def test_build_matrix_of_rankine_and_reflected_rankine():
-    gf = cpt.Delhommeau()
+def test_build_matrix_of_rankine_and_reflected_rankine(nemoh2_solver):
+    gf = nemoh2_solver.green_function
     sphere = Sphere(radius=1.0, ntheta=2, nphi=3, clip_free_surface=True)
 
     S, V = gf.evaluate(sphere.mesh, sphere.mesh, 0.0, np.inf, 0.0)
@@ -144,7 +144,7 @@ def test_alien_sphere(nemoh2_solver):
     assert np.isclose(result.forces["Heave"], 548.5 * np.exp(-2.521j), rtol=1e-2)
 
 
-def test_floating_sphere_finite_depth():
+def test_floating_sphere_finite_depth(nemoh2_solver):
     """Compare with Nemoh 2.0 for some cases of a heaving sphere at the free surface in finite depth."""
     sphere = Sphere(radius=1.0, ntheta=3, nphi=12, clip_free_surface=True)
     sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")

--- a/pytest/test_consistency_with_Nemoh_2.py
+++ b/pytest/test_consistency_with_Nemoh_2.py
@@ -1,24 +1,29 @@
-#!/usr/bin/env python
-# coding: utf-8
 """Quantitatively compare the results of Capytaine with the results from Nemoh 2."""
 
+import pytest
 import numpy as np
 import capytaine as cpt
 
 from capytaine.bodies.predefined.spheres import Sphere
 from capytaine.bodies.predefined.cylinders import HorizontalCylinder
 from capytaine.post_pro.free_surfaces import FreeSurface
-
-from capytaine.bem.problems_and_results import DiffractionProblem, RadiationProblem
-from capytaine.green_functions.delhommeau import Delhommeau
-from capytaine.io.xarray import assemble_dataset
 from capytaine.post_pro.kochin import compute_kochin
 
-gf = Delhommeau(tabulation_nr=328, tabulation_nz=46, tabulation_method='legacy', tabulation_nb_integration_points=251)
-solver = cpt.BEMSolver(engine=cpt.BasicMatrixEngine(matrix_cache_size=0), green_function=gf)
+
+@pytest.fixture
+def nemoh2_solver():
+    gf = cpt.Delhommeau(
+            tabulation_nr=328, tabulation_nz=46,
+            tabulation_method='legacy', tabulation_nb_integration_points=251
+            )
+    solver = cpt.BEMSolver(
+            engine=cpt.BasicMatrixEngine(matrix_cache_size=0),
+            green_function=gf
+            )
+    return solver
 
 
-def test_immersed_sphere():
+def test_immersed_sphere(nemoh2_solver):
     """Compare with Nemoh 2.0 for a sphere in infinite fluid.
 
     The test is ran for two degrees of freedom; due to the symmetries of the problem, the results should be the same.
@@ -28,15 +33,15 @@ def test_immersed_sphere():
     sphere.add_translation_dof(direction=(1, 0, 0), name="Surge")
     sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
 
-    problem = RadiationProblem(body=sphere, radiating_dof="Heave", free_surface=np.inf, water_depth=np.inf)
-    result = solver.solve(problem)
+    problem = cpt.RadiationProblem(body=sphere, radiating_dof="Heave", free_surface=np.inf, water_depth=np.inf)
+    result = nemoh2_solver.solve(problem)
     assert np.isclose(result.added_masses["Heave"],       2187, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.added_masses["Surge"],        0.0, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.radiation_dampings["Heave"],  0.0, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.radiation_dampings["Surge"],  0.0, atol=1e-3*sphere.volume*problem.rho)
 
-    problem = RadiationProblem(body=sphere, radiating_dof="Surge", free_surface=np.inf, water_depth=np.inf)
-    result = solver.solve(problem)
+    problem = cpt.RadiationProblem(body=sphere, radiating_dof="Surge", free_surface=np.inf, water_depth=np.inf)
+    result = nemoh2_solver.solve(problem)
     assert np.isclose(result.added_masses["Surge"],       2194, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.added_masses["Heave"],        0.0, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.radiation_dampings["Surge"],  0.0, atol=1e-3*sphere.volume*problem.rho)
@@ -44,7 +49,7 @@ def test_immersed_sphere():
 
 
 def test_build_matrix_of_rankine_and_reflected_rankine():
-    gf = Delhommeau()
+    gf = cpt.Delhommeau()
     sphere = Sphere(radius=1.0, ntheta=2, nphi=3, clip_free_surface=True)
 
     S, V = gf.evaluate(sphere.mesh, sphere.mesh, 0.0, np.inf, 0.0)
@@ -66,20 +71,20 @@ def test_build_matrix_of_rankine_and_reflected_rankine():
     assert np.allclose(S, S_ref)
 
 
-def test_floating_sphere_finite_freq():
+def test_floating_sphere_finite_freq(nemoh2_solver):
     """Compare with Nemoh 2.0 for some cases of a heaving sphere at the free surface in infinite depth."""
     sphere = Sphere(radius=1.0, ntheta=3, nphi=12, clip_free_surface=True)
     sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
 
     # omega = 1, radiation
-    problem = RadiationProblem(body=sphere, omega=1.0, water_depth=np.inf)
-    result = solver.solve(problem, keep_details=True)
+    problem = cpt.RadiationProblem(body=sphere, omega=1.0, water_depth=np.inf)
+    result = nemoh2_solver.solve(problem, keep_details=True)
     assert np.isclose(result.added_masses["Heave"],       1819.6, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.radiation_dampings["Heave"], 379.39, atol=1e-3*sphere.volume*problem.rho)
 
     # omega = 1, free surface
     grid = np.meshgrid(np.linspace(-50.0, 50.0, 5), np.linspace(-50.0, 50.0, 5))
-    eta = solver.compute_free_surface_elevation(grid, result)
+    eta = nemoh2_solver.compute_free_surface_elevation(grid, result)
     ref = np.array(
             [[-0.4340802E-02-0.4742809E-03j, -0.7986111E-03+0.4840984E-02j, 0.2214827E-02+0.4700642E-02j, -0.7986111E-03+0.4840984E-02j, -0.4340803E-02-0.4742807E-03j],
              [-0.7986111E-03+0.4840984E-02j, 0.5733187E-02-0.2179381E-02j, 0.9460892E-03-0.7079404E-02j, 0.5733186E-02-0.2179381E-02j, -0.7986110E-03+0.4840984E-02j],
@@ -90,8 +95,8 @@ def test_floating_sphere_finite_freq():
     assert np.allclose(eta/(-1j*problem.omega), ref, rtol=1e-4)
 
     # omega = 1, diffraction
-    problem = DiffractionProblem(body=sphere, omega=1.0, water_depth=np.inf)
-    result = solver.solve(problem, keep_details=True)
+    problem = cpt.DiffractionProblem(body=sphere, omega=1.0, water_depth=np.inf)
+    result = nemoh2_solver.solve(problem, keep_details=True)
     assert np.isclose(result.forces["Heave"], 1834.9 * np.exp(-2.933j), rtol=1e-3)
 
     # omega = 1, Kochin function of diffraction problem
@@ -109,18 +114,18 @@ def test_floating_sphere_finite_freq():
     assert np.allclose(kochin, ref_kochin, rtol=1e-3)
 
     # omega = 2, radiation
-    problem = RadiationProblem(body=sphere, omega=2.0, water_depth=np.inf)
-    result = solver.solve(problem)
+    problem = cpt.RadiationProblem(body=sphere, omega=2.0, water_depth=np.inf)
+    result = nemoh2_solver.solve(problem)
     assert np.isclose(result.added_masses["Heave"],       1369.3, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.radiation_dampings["Heave"], 1425.6, atol=1e-3*sphere.volume*problem.rho)
 
     # omega = 2, diffraction
-    problem = DiffractionProblem(body=sphere, omega=2.0, water_depth=np.inf)
-    result = solver.solve(problem)
+    problem = cpt.DiffractionProblem(body=sphere, omega=2.0, water_depth=np.inf)
+    result = nemoh2_solver.solve(problem)
     assert np.isclose(result.forces["Heave"], 5846.6 * np.exp(-2.623j), rtol=1e-3)
 
 
-def test_alien_sphere():
+def test_alien_sphere(nemoh2_solver):
     """Compare with Nemoh 2.0 for some cases of a heaving sphere at the free surface in infinite depth
     for a non-usual gravity and density."""
     sphere = Sphere(radius=1.0, ntheta=3, nphi=12, clip_free_surface=True)
@@ -128,14 +133,14 @@ def test_alien_sphere():
     sphere.add_translation_dof(direction=(1, 0, 0), name="Surge")
 
     # radiation
-    problem = RadiationProblem(body=sphere, rho=450.0, g=1.625, omega=1.0, radiating_dof="Heave")
-    result = solver.solve(problem)
+    problem = cpt.RadiationProblem(body=sphere, rho=450.0, g=1.625, omega=1.0, radiating_dof="Heave")
+    result = nemoh2_solver.solve(problem)
     assert np.isclose(result.added_masses["Heave"],       515, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.radiation_dampings["Heave"], 309, atol=1e-3*sphere.volume*problem.rho)
 
     # diffraction
-    problem = DiffractionProblem(body=sphere, rho=450.0, g=1.625, omega=1.0, water_depth=np.inf)
-    result = solver.solve(problem)
+    problem = cpt.DiffractionProblem(body=sphere, rho=450.0, g=1.625, omega=1.0, water_depth=np.inf)
+    result = nemoh2_solver.solve(problem)
     assert np.isclose(result.forces["Heave"], 548.5 * np.exp(-2.521j), rtol=1e-2)
 
 
@@ -145,8 +150,8 @@ def test_floating_sphere_finite_depth():
     sphere.add_translation_dof(direction=(0, 0, 1), name="Heave")
 
     # omega = 1, radiation
-    problem = RadiationProblem(body=sphere, omega=1.0, radiating_dof="Heave", water_depth=10.0)
-    result = solver.solve(problem, keep_details=True)
+    problem = cpt.RadiationProblem(body=sphere, omega=1.0, radiating_dof="Heave", water_depth=10.0)
+    result = nemoh2_solver.solve(problem, keep_details=True)
     assert np.isclose(result.added_masses["Heave"],       1740.6, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.radiation_dampings["Heave"], 380.46, atol=1e-3*sphere.volume*problem.rho)
 
@@ -155,23 +160,23 @@ def test_floating_sphere_finite_depth():
     assert np.isclose(kochin[0]/(-1j*problem.omega), -0.2267+3.49e-3j, rtol=1e-3)
 
     # omega = 1, diffraction
-    problem = DiffractionProblem(body=sphere, omega=1.0, wave_direction=0.0, water_depth=10.0)
-    result = solver.solve(problem)
+    problem = cpt.DiffractionProblem(body=sphere, omega=1.0, wave_direction=0.0, water_depth=10.0)
+    result = nemoh2_solver.solve(problem)
     assert np.isclose(result.forces["Heave"], 1749.4 * np.exp(-2.922j), rtol=1e-3)
 
     # omega = 2, radiation
-    problem = RadiationProblem(body=sphere, omega=2.0, radiating_dof="Heave", water_depth=10.0)
-    result = solver.solve(problem)
+    problem = cpt.RadiationProblem(body=sphere, omega=2.0, radiating_dof="Heave", water_depth=10.0)
+    result = nemoh2_solver.solve(problem)
     assert np.isclose(result.added_masses["Heave"],       1375.0, atol=1e-3*sphere.volume*problem.rho)
     assert np.isclose(result.radiation_dampings["Heave"], 1418.0, atol=1e-3*sphere.volume*problem.rho)
 
     # omega = 2, diffraction
-    problem = DiffractionProblem(body=sphere, omega=2.0, wave_direction=0.0, water_depth=10.0)
-    result = solver.solve(problem)
+    problem = cpt.DiffractionProblem(body=sphere, omega=2.0, wave_direction=0.0, water_depth=10.0)
+    result = nemoh2_solver.solve(problem)
     assert np.isclose(result.forces["Heave"], 5872.8 * np.exp(-2.627j), rtol=1e-3)
 
 
-def test_two_distant_spheres_in_finite_depth():
+def test_two_distant_spheres_in_finite_depth(nemoh2_solver):
     radius = 0.5
     resolution = 4
     perimeter = 2*np.pi*radius
@@ -181,15 +186,15 @@ def test_two_distant_spheres_in_finite_depth():
     other_buoy = buoy.translated_x(20, name="other_buoy")
     both_buoys = buoy.join_bodies(other_buoy)
     both_buoys.add_translation_dof(name="Surge")
-    problem = RadiationProblem(body=both_buoys, radiating_dof="Surge", water_depth=10, omega=7.0)
-    result = solver.solve(problem)
+    problem = cpt.RadiationProblem(body=both_buoys, radiating_dof="Surge", water_depth=10, omega=7.0)
+    result = nemoh2_solver.solve(problem)
 
     total_volume = 2*4/3*np.pi*radius**3
     assert np.isclose(result.added_masses['Surge'], 124.0, atol=1e-3*total_volume*problem.rho)
     assert np.isclose(result.radiation_dampings['Surge'], 913.3, atol=1e-3*total_volume*problem.rho)
 
 
-def test_multibody():
+def test_multibody(nemoh2_solver):
     """Compare with Nemoh 2.0 for two bodies."""
     sphere = Sphere(radius=1.0, ntheta=5, nphi=20)
     sphere.translate_z(-2.0)
@@ -206,10 +211,10 @@ def test_multibody():
     total_volume = cylinder.volume + sphere.volume
     # both.show()
 
-    problems = [RadiationProblem(body=both, radiating_dof=dof, omega=1.0) for dof in both.dofs]
-    problems += [DiffractionProblem(body=both, wave_direction=0.0, omega=1.0)]
-    results = [solver.solve(problem) for problem in problems]
-    data = assemble_dataset(results)
+    problems = [cpt.RadiationProblem(body=both, radiating_dof=dof, omega=1.0) for dof in both.dofs]
+    problems += [cpt.DiffractionProblem(body=both, wave_direction=0.0, omega=1.0)]
+    results = [nemoh2_solver.solve(problem) for problem in problems]
+    data = cpt.assemble_dataset(results)
 
     data_from_nemoh_2 = np.array([
         [3961.86548, 50.0367661, -3.32347107, 6.36901855E-02, 172.704819, 19.2018471, -5.67303181, -2.98873377],

--- a/pytest/test_post_pro_kochin.py
+++ b/pytest/test_post_pro_kochin.py
@@ -15,7 +15,7 @@ from capytaine.io.xarray import kochin_data_array
 def test_kochin_array_diffraction():
     mesh = cpt.mesh_sphere().immersed_part()
     body = cpt.FloatingBody(mesh=mesh, dofs=cpt.rigid_body_dofs())
-    solver = cpt.BEMSolver(green_function=cpt.Delhommeau(tabulation_nr=5, tabulation_nz=5))
+    solver = cpt.BEMSolver()
     pb_diff = cpt.DiffractionProblem(body=body, wavelength=2.0, wave_direction=0.0)
     res_diff = solver.solve(pb_diff)
     kds_diff = kochin_data_array([res_diff], np.linspace(0.0, np.pi, 3))
@@ -26,7 +26,7 @@ def test_kochin_array_diffraction():
 def test_kochin_array_radiation():
     mesh = cpt.mesh_sphere().immersed_part()
     body = cpt.FloatingBody(mesh=mesh, dofs=cpt.rigid_body_dofs())
-    solver = cpt.BEMSolver(green_function=cpt.Delhommeau(tabulation_nr=5, tabulation_nz=5))
+    solver = cpt.BEMSolver()
     pb_rad = cpt.RadiationProblem(body=body, wavelength=2.0, radiating_dof="Heave")
     res_rad = solver.solve(pb_rad)
     kds_rad = kochin_data_array([res_rad], np.linspace(0.0, np.pi, 3))
@@ -37,7 +37,7 @@ def test_kochin_array_radiation():
 def test_kochin_array_both_radiation_and_diffraction():
     mesh = cpt.mesh_sphere().immersed_part()
     body = cpt.FloatingBody(mesh=mesh, dofs=cpt.rigid_body_dofs())
-    solver = cpt.BEMSolver(green_function=cpt.Delhommeau(tabulation_nr=5, tabulation_nz=5))
+    solver = cpt.BEMSolver()
     pb_diff = cpt.DiffractionProblem(body=body, wavelength=2.0, wave_direction=0.0)
     pb_rad = cpt.RadiationProblem(body=body, wavelength=2.0, radiating_dof="Heave")
     res_both = solver.solve_all([pb_rad, pb_diff])
@@ -49,7 +49,7 @@ def test_kochin_array_both_radiation_and_diffraction():
 def test_kochin_array_diffraction_with_forward_speed():
     mesh = cpt.mesh_sphere().immersed_part()
     body = cpt.FloatingBody(mesh=mesh, dofs=cpt.rigid_body_dofs())
-    solver = cpt.BEMSolver(green_function=cpt.Delhommeau(tabulation_nr=5, tabulation_nz=5))
+    solver = cpt.BEMSolver()
     pb_diff = [cpt.DiffractionProblem(body=body, wavelength=2.0, wave_direction=0.0, forward_speed=u) for u in [0.0, 1.0]]
     res_diff = solver.solve_all(pb_diff)
     kds_diff = kochin_data_array(res_diff, np.linspace(0.0, np.pi, 3))
@@ -60,7 +60,7 @@ def test_kochin_array_diffraction_with_forward_speed():
 def test_kochin_array_radiation_with_forward_speed():
     mesh = cpt.mesh_sphere().immersed_part()
     body = cpt.FloatingBody(mesh=mesh, dofs=cpt.rigid_body_dofs())
-    solver = cpt.BEMSolver(green_function=cpt.Delhommeau(tabulation_nr=5, tabulation_nz=5))
+    solver = cpt.BEMSolver()
     pb_rad = [cpt.RadiationProblem(body=body, wavelength=2.0, radiating_dof="Heave", forward_speed=u, wave_direction=pi) for u in [0.0, 1.0]]
     res_rad = solver.solve_all(pb_rad)
     kds_rad = kochin_data_array(res_rad, np.linspace(0.0, np.pi, 3))
@@ -71,7 +71,7 @@ def test_kochin_array_radiation_with_forward_speed():
 def test_kochin_array_both_radiation_and_diffraction_with_forward_speed():
     mesh = cpt.mesh_sphere().immersed_part()
     body = cpt.FloatingBody(mesh=mesh, dofs=cpt.rigid_body_dofs())
-    solver = cpt.BEMSolver(green_function=cpt.Delhommeau(tabulation_nr=5, tabulation_nz=5))
+    solver = cpt.BEMSolver()
     pb_diff = [cpt.DiffractionProblem(body=body, wavelength=2.0, wave_direction=pi, forward_speed=u) for u in [0.0, 1.0]]
     pb_rad = [cpt.RadiationProblem(body=body, wavelength=2.0, radiating_dof="Heave", wave_direction=pi, forward_speed=u) for u in [0.0, 1.0]]
     res_both = solver.solve_all(pb_rad + pb_diff)
@@ -113,4 +113,3 @@ def test_fill_dataset_with_kochin_functions():
     # Because of the symmetries of the body
     assert np.isclose(ds['kochin_diffraction'].sel(wave_direction=-pi/2, theta=0.0),
                       ds['kochin_diffraction'].sel(wave_direction=0.0, theta=pi/2))
-


### PR DESCRIPTION
- Add missing info in documentation
- Better `__str__` and `__repr__`
- Change default tabulation size to 676x373 with 1000 points for the theta-integrals.