### PR TITLE
Clip the mesh when setting a problem

### DIFF
--- a/capytaine/green_functions/libDelhommeau/src/Green_wave.f90
+++ b/capytaine/green_functions/libDelhommeau/src/Green_wave.f90
@@ -63,11 +63,6 @@ CONTAINS
     END IF
     dzdx3 = wavenumber
 
-    IF (z > -1e-8) THEN
-      PRINT*, "Error: Impossible to compute the wave part of the Green function due to panels on the free surface (z=0) or above."
-      ERROR STOP
-    ENDIF
-
     !=======================================================
     ! Evaluate the elementary integrals depending on z and r
     !=======================================================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -54,6 +54,8 @@ Minor changes
 
 * Add a `faces_max_radius` argument to the predefined geometries from :mod:`~cpt.meshes.predefined` to set up the resolution by giving a length scale for the panels (:pull:`459`).
 
+* Automatically clip the mesh (and display a warning) when a problem is initialized with a mesh above the free surface or below the sea bottom (:pull:`486`).
+
 Bug fixes
 ~~~~~~~~~
 

--- a/pytest/test_bem_problems_and_results.py
+++ b/pytest/test_bem_problems_and_results.py
@@ -78,6 +78,25 @@ def test_LinearPotentialFlowProblem(sphere):
     assert res.body is pb.body
 
 
+def test_mesh_above_the_free_surface(caplog):
+    with caplog.at_level(logging.WARNING):
+        body = cpt.FloatingBody(mesh=cpt.mesh_sphere(), dofs=cpt.rigid_body_dofs())
+        pb = cpt.RadiationProblem(body=body, omega=1.0)
+    assert '50 panels above the free surface' in caplog.text
+    assert np.all(pb.body.mesh.vertices[:, 2].max() <= 0.0)
+
+
+def test_mesh_below_the_sea_bottom(caplog):
+    with caplog.at_level(logging.WARNING):
+        body = cpt.FloatingBody(
+                mesh=cpt.mesh_sphere(radius=0.5, center=(0, 0, -1.0)),
+                dofs=cpt.rigid_body_dofs()
+                )
+        pb = cpt.RadiationProblem(body=body, omega=1.0, water_depth=1.0)
+    assert '50 panels below the sea bottom' in caplog.text
+    assert np.all(pb.body.mesh.vertices[:, 2].min() >= -1.0)
+
+
 def test_backward_compatibility_with_sea_bottom_argument(caplog):
     with caplog.at_level(logging.WARNING):
         pb = cpt.DiffractionProblem(sea_bottom=-10.0)


### PR DESCRIPTION
Fixes #418

By always clipping the mesh when setting up a problem, I can safely remove the error message in Fortran.
Advance users calling lower-level functions will need to take care to have only panels below the free surface.