### PR TITLE
Fix logs in inertia & stiffness

### DIFF
--- a/capytaine/bodies/bodies.py
+++ b/capytaine/bodies/bodies.py
@@ -512,6 +512,8 @@ class FloatingBody(ClippableMixin, Abstract3DObject):
             raise AttributeError("Cannot compute hydrostatics stiffness on {} since no dof has been defined.".format(self.name))
 
         def divergence_dof(influenced_dof):
+            if influenced_dof in [*TRANSLATION_DOFS_DIRECTIONS, *ROTATION_DOFS_AXIS]:
+                return 0.0
             if divergence is None:
                 return 0.0
             elif isinstance(divergence, dict) and influenced_dof in divergence.keys():
@@ -636,7 +638,7 @@ respective inertia coefficients are assigned as NaN.")
                                                   radiating_dof=rigid_dof_names)
         elif output_type == "all_dofs":
             if len(non_rigid_dofs) > 0:
-                LOG.warning("Non-rigid dofs: {non_rigid_dofs} are detected and \
+                LOG.warning(f"Non-rigid dofs: {non_rigid_dofs} are detected and \
 respective inertia coefficients are assigned as NaN.")
 
             inertia_matrix_xr = total_mass_xr


### PR DESCRIPTION
When passing a dict of divergence to`compute_hydrostatic_stiffness`, if complains if no data is provided for rigid DoFs. This PR automatically sets the divergence of rigid dofs to 0 instead of printing a warning

Also fix a log in the definition of the inertia matrix

Relevant code
```python
import capytaine as cpt
import numpy as np
from capytaine.meshes.predefined import mesh_sphere

body = cpt.FloatingBody(mesh_sphere())
body.center_of_mass = (0, 0, 0)
body.add_all_rigid_body_dofs()
body.dofs["x-dof"] = np.array([(x, 0, 0) for x, _, _ in body.mesh.faces_centers])
divergence = {"x-dof": np.ones(body.mesh.nb_faces)}
body.compute_hydrostatic_stiffness(divergence=divergence)
```

Current logs:
```
Computing hydrostatic stiffness without the divergence of Surge
Computing hydrostatic stiffness without the divergence of Sway
Computing hydrostatic stiffness without the divergence of Heave
Computing hydrostatic stiffness without the divergence of Roll
Computing hydrostatic stiffness without the divergence of Pitch
Computing hydrostatic stiffness without the divergence of Yaw
Computing hydrostatic stiffness without the divergence of Surge
Computing hydrostatic stiffness without the divergence of Sway
Computing hydrostatic stiffness without the divergence of Heave
Computing hydrostatic stiffness without the divergence of Roll
Computing hydrostatic stiffness without the divergence of Pitch
Computing hydrostatic stiffness without the divergence of Yaw
Computing hydrostatic stiffness without the divergence of Surge
Computing hydrostatic stiffness without the divergence of Sway
Computing hydrostatic stiffness without the divergence of Heave
Computing hydrostatic stiffness without the divergence of Roll
Computing hydrostatic stiffness without the divergence of Pitch
Computing hydrostatic stiffness without the divergence of Yaw
Computing hydrostatic stiffness without the divergence of Surge
Computing hydrostatic stiffness without the divergence of Sway
Computing hydrostatic stiffness without the divergence of Heave
Computing hydrostatic stiffness without the divergence of Roll
Computing hydrostatic stiffness without the divergence of Pitch
Computing hydrostatic stiffness without the divergence of Yaw
Computing hydrostatic stiffness without the divergence of Surge
Computing hydrostatic stiffness without the divergence of Sway
Computing hydrostatic stiffness without the divergence of Heave
Computing hydrostatic stiffness without the divergence of Roll
Computing hydrostatic stiffness without the divergence of Pitch
Computing hydrostatic stiffness without the divergence of Yaw
Computing hydrostatic stiffness without the divergence of Surge
Computing hydrostatic stiffness without the divergence of Sway
Computing hydrostatic stiffness without the divergence of Heave
Computing hydrostatic stiffness without the divergence of Roll
Computing hydrostatic stiffness without the divergence of Pitch
Computing hydrostatic stiffness without the divergence of Yaw
Computing hydrostatic stiffness without the divergence of Surge
Computing hydrostatic stiffness without the divergence of Sway
Computing hydrostatic stiffness without the divergence of Heave
Computing hydrostatic stiffness without the divergence of Roll
Computing hydrostatic stiffness without the divergence of Pitch
Computing hydrostatic stiffness without the divergence of Yaw
```