### PR TITLE
Remove BEMIO optional dependency to build wheels for 2.1.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,10 @@ scripts = {capytaine = "capytaine.ui.cli:main"}
 dynamic = ['version']
 
 [project.optional-dependencies]
-optional = ["matplotlib", "joblib>=1.3", "meshio", "quadpy-gpl", "bemio @ https://github.com/mancellin/bemio/archive/fa3a6d3d4b0862491c3723919ec8ee45cc7d055a.zip"]
-build = ["numpy<=1.26.2", "ninja", "meson-python", "charset-normalizer"]
+optional = [
+  "matplotlib", "joblib>=1.3", "meshio", "quadpy-gpl",
+  # "bemio @ https://github.com/mancellin/bemio/archive/fa3a6d3d4b0862491c3723919ec8ee45cc7d055a.zip"
+]
 test = ["pytest"]
 docs = ["sphinx", "sphinx-toolbox", "sphinxcontrib-proof", "sphinxcontrib-mermaid"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ optional = [
   "matplotlib", "joblib>=1.3", "meshio", "quadpy-gpl",
   # "bemio @ https://github.com/mancellin/bemio/archive/fa3a6d3d4b0862491c3723919ec8ee45cc7d055a.zip"
 ]
+build = ["numpy<=1.26.2", "ninja", "meson-python", "charset-normalizer"]
 test = ["pytest"]
 docs = ["sphinx", "sphinx-toolbox", "sphinxcontrib-proof", "sphinxcontrib-mermaid"]
 


### PR DESCRIPTION
Fixes #495 (hopefully)