### PR TITLE
Rename "tabulation_method" in libDelhommeau

### DIFF
--- a/capytaine/green_functions/delhommeau.py
+++ b/capytaine/green_functions/delhommeau.py
@@ -103,11 +103,11 @@ class Delhommeau(AbstractGreenFunction):
         self.fortran_core = import_module(f"capytaine.green_functions.libs.{self.fortran_core_basename}_{self.floating_point_precision}")
 
         self.tabulation_grid_shape = tabulation_grid_shape
-        fortran_indices_for_methods = {
+        fortran_enum = {
                 'legacy': self.fortran_core.delhommeau_integrals.legacy_grid,
                 'scaled_nemoh3': self.fortran_core.delhommeau_integrals.scaled_nemoh3_grid,
                               }
-        self.tabulation_grid_shape_index = fortran_indices_for_methods[tabulation_grid_shape]
+        self.tabulation_grid_shape_index = fortran_enum[tabulation_grid_shape]
 
         self._create_or_load_tabulation(tabulation_nr, tabulation_rmax, tabulation_nz, tabulation_zmin, tabulation_nb_integration_points)
 

--- a/capytaine/green_functions/delhommeau.py
+++ b/capytaine/green_functions/delhommeau.py
@@ -24,7 +24,7 @@ _default_parameters = dict(
     tabulation_nz=372,
     tabulation_zmin=-251.0,
     tabulation_nb_integration_points=1000,
-    tabulation_method="scaled_nemoh3",
+    tabulation_grid_shape="scaled_nemoh3",
     finite_depth_prony_decomposition_method="fortran",
     floating_point_precision="float64"
 )
@@ -55,7 +55,7 @@ class Delhommeau(AbstractGreenFunction):
         Number of points for the numerical integration w.r.t. :math:`theta` of
         Delhommeau's integrals
         Default: 1000
-    tabulation_method: string, optional
+    tabulation_grid_shape: string, optional
         Either :code:`"legacy"` or :code:`"scaled_nemoh3"`, which are the two
         methods currently implemented.
         Default: :code:`"scaled_nemoh3"`
@@ -75,7 +75,7 @@ class Delhommeau(AbstractGreenFunction):
     fortran_core:
         Compiled Fortran module with functions used to compute the Green
         function.
-    tabulation_method_index: int
+    tabulation_grid_shape_index: int
         Integer passed to Fortran code to describe which method is used.
     tabulated_r_range: numpy.array of shape (tabulation_nr,) and type floating_point_precision
     tabulated_z_range: numpy.array of shape (tabulation_nz,) and type floating_point_precision
@@ -93,7 +93,7 @@ class Delhommeau(AbstractGreenFunction):
                  tabulation_nz=_default_parameters["tabulation_nz"],
                  tabulation_zmin=_default_parameters["tabulation_zmin"],
                  tabulation_nb_integration_points=_default_parameters["tabulation_nb_integration_points"],
-                 tabulation_method=_default_parameters["tabulation_method"],
+                 tabulation_grid_shape=_default_parameters["tabulation_grid_shape"],
                  finite_depth_prony_decomposition_method=_default_parameters["finite_depth_prony_decomposition_method"],
                  floating_point_precision=_default_parameters["floating_point_precision"],
                  ):
@@ -102,12 +102,12 @@ class Delhommeau(AbstractGreenFunction):
 
         self.fortran_core = import_module(f"capytaine.green_functions.libs.{self.fortran_core_basename}_{self.floating_point_precision}")
 
-        self.tabulation_method = tabulation_method
+        self.tabulation_grid_shape = tabulation_grid_shape
         fortran_indices_for_methods = {
                 'legacy': self.fortran_core.delhommeau_integrals.legacy_method,
                 'scaled_nemoh3': self.fortran_core.delhommeau_integrals.scaled_nemoh3_method,
                               }
-        self.tabulation_method_index = fortran_indices_for_methods[tabulation_method]
+        self.tabulation_grid_shape_index = fortran_indices_for_methods[tabulation_grid_shape]
 
         self._create_or_load_tabulation(tabulation_nr, tabulation_rmax, tabulation_nz, tabulation_zmin, tabulation_nb_integration_points)
 
@@ -120,7 +120,7 @@ class Delhommeau(AbstractGreenFunction):
             'tabulation_nz': tabulation_nz,
             'tabulation_zmin': tabulation_zmin,
             'tabulation_nb_integration_points': tabulation_nb_integration_points,
-            'tabulation_method': tabulation_method,
+            'tabulation_grid_shape': tabulation_grid_shape,
             'finite_depth_prony_decomposition_method': finite_depth_prony_decomposition_method,
             'floating_point_precision': floating_point_precision,
         }
@@ -164,7 +164,7 @@ class Delhommeau(AbstractGreenFunction):
 
         filename = "tabulation_{}_{}_{}_{}_{}_{}_{}_{}.npz".format(
             self.fortran_core_basename, self.floating_point_precision,
-            self.tabulation_method,
+            self.tabulation_grid_shape,
             tabulation_nr, tabulation_rmax, tabulation_nz, tabulation_zmin,
             tabulation_nb_integration_points
         )
@@ -180,10 +180,10 @@ class Delhommeau(AbstractGreenFunction):
         else:
             LOG.warning("Precomputing tabulation, it may take a few seconds.")
             self.tabulated_r_range = self.fortran_core.delhommeau_integrals.default_r_spacing(
-                    tabulation_nr, tabulation_rmax, self.tabulation_method_index
+                    tabulation_nr, tabulation_rmax, self.tabulation_grid_shape_index
                     )
             self.tabulated_z_range = self.fortran_core.delhommeau_integrals.default_z_spacing(
-                    tabulation_nz, tabulation_zmin, self.tabulation_method_index
+                    tabulation_nz, tabulation_zmin, self.tabulation_grid_shape_index
                     )
             self.tabulated_integrals = self.fortran_core.delhommeau_integrals.construct_tabulation(
                     self.tabulated_r_range, self.tabulated_z_range, tabulation_nb_integration_points
@@ -355,7 +355,7 @@ class Delhommeau(AbstractGreenFunction):
             *mesh2.quadrature_points,
             wavenumber, water_depth,
             coeffs,
-            self.tabulation_method_index, self.tabulated_r_range, self.tabulated_z_range, self.tabulated_integrals,
+            self.tabulation_grid_shape_index, self.tabulated_r_range, self.tabulated_z_range, self.tabulated_integrals,
             lamda_exp, a_exp,
             mesh1 is mesh2, adjoint_double_layer,
             S, K

--- a/capytaine/green_functions/delhommeau.py
+++ b/capytaine/green_functions/delhommeau.py
@@ -104,8 +104,8 @@ class Delhommeau(AbstractGreenFunction):
 
         self.tabulation_grid_shape = tabulation_grid_shape
         fortran_indices_for_methods = {
-                'legacy': self.fortran_core.delhommeau_integrals.legacy_method,
-                'scaled_nemoh3': self.fortran_core.delhommeau_integrals.scaled_nemoh3_method,
+                'legacy': self.fortran_core.delhommeau_integrals.legacy_grid,
+                'scaled_nemoh3': self.fortran_core.delhommeau_integrals.scaled_nemoh3_grid,
                               }
         self.tabulation_grid_shape_index = fortran_indices_for_methods[tabulation_grid_shape]
 

--- a/capytaine/green_functions/libDelhommeau/benchmarks/openmp/benchmark_omp.f90
+++ b/capytaine/green_functions/libDelhommeau/benchmarks/openmp/benchmark_omp.f90
@@ -29,7 +29,7 @@ real(kind=pre), dimension(nb_faces, nb_quadrature_points, 3) :: quadrature_point
 real(kind=pre), dimension(nb_faces, nb_quadrature_points) :: quadrature_weights
 
 ! Tabulation of the integrals used in the Green function
-integer, parameter :: tabulation_method = 1
+integer, parameter :: tabulation_grid_shape = 1
 integer, parameter :: tabulation_nr = 328
 integer, parameter :: tabulation_nz = 46
 real(kind=pre), dimension(tabulation_nr)                       :: tabulated_r
@@ -56,8 +56,8 @@ call RANDOM_INIT(.true.,.true.)
 allocate(S(nb_faces, nb_faces))
 allocate(K(nb_faces, nb_faces, 1))
 
-tabulated_r(:) = default_r_spacing(tabulation_nr, 100d0, tabulation_method)
-tabulated_z(:) = default_z_spacing(tabulation_nz, -251d0, tabulation_method)
+tabulated_r(:) = default_r_spacing(tabulation_nr, 100d0, tabulation_grid_shape)
+tabulated_z(:) = default_z_spacing(tabulation_nz, -251d0, tabulation_grid_shape)
 tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, 1000)
 
 wavenumber = 1.0
@@ -102,7 +102,7 @@ do n_threads = 1, OMP_GET_MAX_THREADS()
     nb_quadrature_points, quadrature_points, quadrature_weights,      &
     wavenumber, depth,                                                &
     coeffs,                                                           &
-    tabulation_method, tabulated_r, tabulated_z, tabulated_integrals, &
+    tabulation_grid_shape, tabulated_r, tabulated_z, tabulated_integrals, &
     nexp, ambda, ar,                                                  &
     .false., .true.,                                                  &
     S, K)
@@ -120,7 +120,7 @@ do n_threads = 1, OMP_GET_MAX_THREADS()
     nb_quadrature_points, quadrature_points, quadrature_weights,      &
     wavenumber, depth,                                                &
     coeffs,                                                           &
-    tabulation_method, tabulated_r, tabulated_z, tabulated_integrals, &
+    tabulation_grid_shape, tabulated_r, tabulated_z, tabulated_integrals, &
     nexp, ambda, ar,                                                  &
     .false., .true.,                                                  &
     S, K)
@@ -138,7 +138,7 @@ do n_threads = 1, OMP_GET_MAX_THREADS()
     nb_quadrature_points, quadrature_points, quadrature_weights,      &
     wavenumber, depth,                                                &
     coeffs,                                                           &
-    tabulation_method, tabulated_r, tabulated_z, tabulated_integrals, &
+    tabulation_grid_shape, tabulated_r, tabulated_z, tabulated_integrals, &
     nexp, ambda, ar,                                                  &
     .true., .true.,                                                   &
     S, K)

--- a/capytaine/green_functions/libDelhommeau/benchmarks/profiling/benchmark_profiling.f90
+++ b/capytaine/green_functions/libDelhommeau/benchmarks/profiling/benchmark_profiling.f90
@@ -29,7 +29,7 @@ real(kind=pre), dimension(nb_faces, nb_quadrature_points, 3) :: quadrature_point
 real(kind=pre), dimension(nb_faces, nb_quadrature_points) :: quadrature_weights
 
 ! Tabulation of the integrals used in the Green function
-integer, parameter :: tabulation_method = 1
+integer, parameter :: tabulation_grid_shape = 1
 integer, parameter :: tabulation_nr = 676
 integer, parameter :: tabulation_nz = 372
 real(kind=pre), dimension(tabulation_nr)                       :: tabulated_r
@@ -56,8 +56,8 @@ call RANDOM_INIT(.true.,.true.)
 allocate(S(nb_faces, nb_faces))
 allocate(K(nb_faces, nb_faces, 1))
 
-tabulated_r(:) = default_r_spacing(tabulation_nr, 100d0, tabulation_method)
-tabulated_z(:) = default_z_spacing(tabulation_nz, -251d0, tabulation_method)
+tabulated_r(:) = default_r_spacing(tabulation_nr, 100d0, tabulation_grid_shape)
+tabulated_z(:) = default_z_spacing(tabulation_nz, -251d0, tabulation_grid_shape)
 tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, 1000)
 
 wavenumber = 1.0
@@ -93,7 +93,7 @@ do i=1, 1
         nb_quadrature_points, quadrature_points, quadrature_weights,      &
         wavenumber, depth,                                                &
         coeffs,                                                           &
-        tabulation_method, tabulated_r, tabulated_z, tabulated_integrals, &
+        tabulation_grid_shape, tabulated_r, tabulated_z, tabulated_integrals, &
         nexp, ambda, ar,                                                  &
         .false., .true.,                                                  &
         S, K)
@@ -110,7 +110,7 @@ do i=1, 1
    !      nb_quadrature_points, quadrature_points, quadrature_weights,      &
    !      wavenumber, depth,                                                &
    !      coeffs,                                                           &
-   !      tabulation_method, tabulated_r, tabulated_z, tabulated_integrals, &
+   !      tabulation_grid_shape, tabulated_r, tabulated_z, tabulated_integrals, &
    !      nexp, ambda, ar,                                                  &
    !      .false., .true.,                                                  &
    !      S, K)
@@ -127,7 +127,7 @@ do i=1, 1
    !      nb_quadrature_points, quadrature_points, quadrature_weights,      &
    !      wavenumber, depth,                                                &
    !      coeffs,                                                           &
-   !      tabulation_method, tabulated_r, tabulated_z, tabulated_integrals, &
+   !      tabulation_grid_shape, tabulated_r, tabulated_z, tabulated_integrals, &
    !      nexp, ambda, ar,                                                  &
    !      .true., .true.,                                                   &
    !      S, K)

--- a/capytaine/green_functions/libDelhommeau/benchmarks/tabulations/benchmark_tabulation.f90
+++ b/capytaine/green_functions/libDelhommeau/benchmarks/tabulations/benchmark_tabulation.f90
@@ -5,7 +5,7 @@ use delhommeau_integrals
 
 implicit none
 
-integer, parameter :: tabulation_method = 1
+integer, parameter :: tabulation_grid_shape = 1
 integer, parameter :: n_tabulation = 4
 integer, parameter :: n_samples = 1000
 integer :: i_sample
@@ -60,14 +60,14 @@ do i_tabulation = 1, n_tabulation
   allocate(tabulated_z(tabulation_nz(i_tabulation)))
   allocate(tabulated_integrals(tabulation_nr(i_tabulation), tabulation_nz(i_tabulation), 2, 2))
 
-  tabulated_r(:) = default_r_spacing(tabulation_nr(i_tabulation), 100d0, tabulation_method)
-  tabulated_z(:) = default_z_spacing(tabulation_nz(i_tabulation), -251d0, tabulation_method)
+  tabulated_r(:) = default_r_spacing(tabulation_nr(i_tabulation), 100d0, tabulation_grid_shape)
+  tabulated_z(:) = default_z_spacing(tabulation_nz(i_tabulation), -251d0, tabulation_grid_shape)
   tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, 1000)
 
   call system_clock(starting_time)
   do i_sample = 1, n_samples
       integrals(i_sample, :, :) = pick_in_default_tabulation(r(i_sample), z(i_sample), &
-        tabulation_method, tabulated_r, tabulated_z, tabulated_integrals)
+        tabulation_grid_shape, tabulated_r, tabulated_z, tabulated_integrals)
   enddo
   call system_clock(final_time)
   print*, "Interpolate         :", (final_time - starting_time)/clock_rate_in_ns/n_samples, " ns"

--- a/capytaine/green_functions/libDelhommeau/examples/minimal/minimal_example.f90
+++ b/capytaine/green_functions/libDelhommeau/examples/minimal/minimal_example.f90
@@ -27,7 +27,7 @@ program test
   real(kind=pre), dimension(nb_faces, nb_quadrature_points) :: quadrature_weights
 
   ! Tabulation of the integrals used in the Green function
-  integer, parameter :: tabulation_method = 1   ! scaled_nemoh3 method
+  integer, parameter :: tabulation_grid_shape = 1   ! scaled_nemoh3 method
   integer, parameter :: tabulation_nr = 676
   integer, parameter :: tabulation_nz = 372
   real(kind=pre), dimension(tabulation_nr)                       :: tabulated_r
@@ -47,8 +47,8 @@ program test
   integer :: i
   real(kind=pre), dimension(3) :: coeffs
 
-  tabulated_r(:) = default_r_spacing(tabulation_nr, 100d0, tabulation_method)
-  tabulated_z(:) = default_z_spacing(tabulation_nz, -251d0, tabulation_method)
+  tabulated_r(:) = default_r_spacing(tabulation_nr, 100d0, tabulation_grid_shape)
+  tabulated_z(:) = default_z_spacing(tabulation_nz, -251d0, tabulation_grid_shape)
   tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, 1000)
 
   depth = ieee_value(depth, ieee_positive_inf)
@@ -93,7 +93,7 @@ program test
     face_center, face_normal, face_area, face_radius,                 &
     nb_quadrature_points, quadrature_points, quadrature_weights,      &
     ZERO, depth, coeffs,                                              &
-    tabulation_method, tabulated_r, tabulated_z, tabulated_integrals, &
+    tabulation_grid_shape, tabulated_r, tabulated_z, tabulated_integrals, &
     nexp, ambda, ar,                                                  &
     .true., .true.,                                                   &
     S, K)
@@ -114,7 +114,7 @@ program test
     face_center, face_normal, face_area, face_radius,                 &
     nb_quadrature_points, quadrature_points, quadrature_weights,      &
     wavenumber, depth, coeffs,                                        &
-    tabulation_method, tabulated_r, tabulated_z, tabulated_integrals, &
+    tabulation_grid_shape, tabulated_r, tabulated_z, tabulated_integrals, &
     nexp, ambda, ar,                                                  &
     .true., .true.,                                                   &
     S, K)
@@ -135,7 +135,7 @@ program test
     face_center, face_normal, face_area, face_radius,                 &
     nb_quadrature_points, quadrature_points, quadrature_weights,      &
     wavenumber, depth, coeffs,                                        &
-    tabulation_method, tabulated_r, tabulated_z, tabulated_integrals, &
+    tabulation_grid_shape, tabulated_r, tabulated_z, tabulated_integrals, &
     nexp, ambda, ar,                                                  &
     .true., .true.,                                                   &
     S, K)
@@ -167,7 +167,7 @@ program test
     face_center, face_normal, face_area, face_radius,                 &
     nb_quadrature_points, quadrature_points, quadrature_weights,      &
     wavenumber, depth, coeffs,                                        &
-    tabulation_method, tabulated_r, tabulated_z, tabulated_integrals, &
+    tabulation_grid_shape, tabulated_r, tabulated_z, tabulated_integrals, &
     nexp, ambda, ar,                                                  &
     .true., .true.,                                                   &
     S, K)
@@ -198,7 +198,7 @@ program test
     face_center, face_normal, face_area, face_radius,                 &
     nb_quadrature_points, quadrature_points, quadrature_weights,      &
     wavenumber, depth, coeffs,                                        &
-    tabulation_method, tabulated_r, tabulated_z, tabulated_integrals, &
+    tabulation_grid_shape, tabulated_r, tabulated_z, tabulated_integrals, &
     nexp, ambda, ar,                                                  &
     .true., .true.,                                                   &
     S, K)

--- a/capytaine/green_functions/libDelhommeau/src/Delhommeau_integrals.f90
+++ b/capytaine/green_functions/libDelhommeau/src/Delhommeau_integrals.f90
@@ -21,8 +21,8 @@ module delhommeau_integrals
 
   implicit none
 
-  integer, parameter :: LEGACY_METHOD = 0  ! Nemoh 2
-  integer, parameter :: SCALED_NEMOH3_METHOD = 1
+  integer, parameter :: LEGACY_GRID = 0  ! Nemoh 2
+  integer, parameter :: SCALED_NEMOH3_GRID = 1
 
   public :: numerical_integration
   public :: asymptotic_approximations
@@ -209,7 +209,7 @@ contains
 
     default_r_spacing(1) = 0.0
 
-    if (method == LEGACY_METHOD) then
+    if (method == LEGACY_GRID) then
       do concurrent (i = 2:nr)
         default_r_spacing(i) = min(                    &
                                  10**((i-1.0)/5.0 - 6.0), &
@@ -243,7 +243,7 @@ contains
     integer :: j
     real(kind=pre) :: dz
 
-    if (method == LEGACY_METHOD) then
+    if (method == LEGACY_GRID) then
       do concurrent (j = 1:nz)
         default_z_spacing(j) = -min(10**(j/5.0-6.0), 10**(j/8.0-4.5))
         ! change of slope at z = -1e-2
@@ -301,7 +301,7 @@ contains
       integer :: index_of_1
       real(kind=pre) :: rmax
 
-      if (method == LEGACY_METHOD) then
+      if (method == LEGACY_GRID) then
         if (r < 1e-6) then
           nearest_r_index = 2
         else if (r < 1.0) then
@@ -337,7 +337,7 @@ contains
       absz = abs(z)
       nz = size(z_range)
 
-      if (method == LEGACY_METHOD) then
+      if (method == LEGACY_GRID) then
         if (absz > 1e-2) then
           nearest_z_index = int(8*(log10(absz) + 4.5))
         else

--- a/capytaine/green_functions/libDelhommeau/src/Green_wave.f90
+++ b/capytaine/green_functions/libDelhommeau/src/Green_wave.f90
@@ -28,7 +28,7 @@ CONTAINS
 
   SUBROUTINE COLLECT_DELHOMMEAU_INTEGRALS                        &
       (X0I, X0J, wavenumber,                                     &
-      tabulation_method, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
+      tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
       FS, VS)
 
     ! Inputs
@@ -36,7 +36,7 @@ CONTAINS
     REAL(KIND=PRE),                           INTENT(IN) :: wavenumber
 
     ! Tabulated data
-    INTEGER,                                  INTENT(IN) :: tabulation_method
+    INTEGER,                                  INTENT(IN) :: tabulation_grid_shape
     REAL(KIND=PRE), DIMENSION(:),             INTENT(IN) :: tabulated_r_range
     REAL(KIND=PRE), DIMENSION(:),             INTENT(IN) :: tabulated_z_range
     REAL(KIND=PRE), DIMENSION(size(tabulated_r_range), size(tabulated_z_range), 2, 2), INTENT(IN) :: tabulated_integrals
@@ -70,9 +70,12 @@ CONTAINS
       ! No tabulation, fully recompute the Green function each time.
       integrals = numerical_integration(r, z, 500)
     ELSE
-      IF ((abs(z) < abs(tabulated_z_range(size(tabulated_z_range)))) .AND. (r < tabulated_r_range(size(tabulated_r_range)))) THEN
+      IF ((abs(z) < abs(tabulated_z_range(size(tabulated_z_range)))) &
+          .AND. (r < tabulated_r_range(size(tabulated_r_range)))) THEN
         ! Within the range of tabulated data
-        integrals = pick_in_default_tabulation(r, z, tabulation_method, tabulated_r_range, tabulated_z_range, tabulated_integrals)
+        integrals = pick_in_default_tabulation( &
+            r, z, tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals &
+        )
       ELSE
         ! Asymptotic expression for distant panels
         integrals = asymptotic_approximations(MAX(r, 1e-10), z)
@@ -99,7 +102,7 @@ CONTAINS
 
   SUBROUTINE WAVE_PART_INFINITE_DEPTH &
       (X0I, X0J, wavenumber,          &
-      tabulation_method, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
+      tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
       SP, VSP_SYM, VSP_ANTISYM)
     ! Compute the wave part of the Green function in the infinite depth case.
     ! This is mostly the integral computed by the subroutine above.
@@ -110,7 +113,7 @@ CONTAINS
     REAL(KIND=PRE), DIMENSION(3),             INTENT(IN)  :: X0J   ! Coordinates of the center of the integration panel
 
     ! Tabulated data
-    INTEGER,                                  INTENT(IN) :: tabulation_method
+    INTEGER,                                  INTENT(IN) :: tabulation_grid_shape
     REAL(KIND=PRE), DIMENSION(:),             INTENT(IN) :: tabulated_r_range
     REAL(KIND=PRE), DIMENSION(:),             INTENT(IN) :: tabulated_z_range
     REAL(KIND=PRE), DIMENSION(size(tabulated_r_range), size(tabulated_z_range), 2, 2), INTENT(IN) :: tabulated_integrals
@@ -126,7 +129,7 @@ CONTAINS
     ! The integrals
     CALL COLLECT_DELHOMMEAU_INTEGRALS(                           &
       X0I, X0J, wavenumber,                                      &
-      tabulation_method, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
+      tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
       SP, VSP(:))
     SP  = 2*wavenumber*SP
     VSP = 2*wavenumber*VSP
@@ -151,7 +154,7 @@ CONTAINS
 
   SUBROUTINE WAVE_PART_FINITE_DEPTH &
       (X0I, X0J, wavenumber, depth, &
-      tabulation_method, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
+      tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
       NEXP, AMBDA, AR,              &
       SP, VSP_SYM, VSP_ANTISYM)
     ! Compute the frequency-dependent part of the Green function in the finite depth case.
@@ -162,7 +165,7 @@ CONTAINS
     REAL(KIND=PRE), DIMENSION(3),             INTENT(IN) :: X0J  ! Coordinates of the center of the integration panel
 
     ! Tabulated data
-    INTEGER,                                  INTENT(IN) :: tabulation_method
+    INTEGER,                                  INTENT(IN) :: tabulation_grid_shape
     REAL(KIND=PRE), DIMENSION(:),             INTENT(IN) :: tabulated_r_range
     REAL(KIND=PRE), DIMENSION(:),             INTENT(IN) :: tabulated_z_range
     REAL(KIND=PRE), DIMENSION(size(tabulated_r_range), size(tabulated_z_range), 2, 2), INTENT(IN) :: tabulated_integrals
@@ -198,7 +201,7 @@ CONTAINS
     ! 1.a First infinite depth problem
     CALL COLLECT_DELHOMMEAU_INTEGRALS(                           &
       XI(:), XJ(:), wavenumber,                                  &
-      tabulation_method, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
+      tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
       FS(1), VS(:, 1))
 
 #ifndef XIE_CORRECTION
@@ -216,7 +219,7 @@ CONTAINS
     XJ(3) =  X0J(3)
     CALL COLLECT_DELHOMMEAU_INTEGRALS(                           &
       XI(:), XJ(:), wavenumber,                                  &
-      tabulation_method, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
+      tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
       FS(2), VS(:, 2))
     VS(3, 2) = -VS(3, 2) ! Reflection of the output vector
 
@@ -229,7 +232,7 @@ CONTAINS
     XJ(3) = -X0J(3) - 2*depth
     CALL COLLECT_DELHOMMEAU_INTEGRALS(                           &
       XI(:), XJ(:), wavenumber,                                  &
-      tabulation_method, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
+      tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
       FS(3), VS(:, 3))
 
 #ifndef XIE_CORRECTION
@@ -241,7 +244,7 @@ CONTAINS
     XJ(3) = -X0J(3) - 2*depth
     CALL COLLECT_DELHOMMEAU_INTEGRALS(                           &
       XI(:), XJ(:), wavenumber,                                  &
-      tabulation_method, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
+      tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
       FS(4), VS(:, 4))
     VS(3, 4) = -VS(3, 4) ! Reflection of the output vector
 

--- a/capytaine/green_functions/libDelhommeau/src/matrices.f90
+++ b/capytaine/green_functions/libDelhommeau/src/matrices.f90
@@ -27,7 +27,7 @@ CONTAINS
       nb_quad_points, quad_points, quad_weights,      &
       wavenumber, depth,                              &
       coeffs,                                         &
-      tabulation_method, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
+      tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
       NEXP, AMBDA, AR,                                &
       same_body, adjoint_double_layer,                &
       S, K)
@@ -52,7 +52,7 @@ CONTAINS
     REAL(KIND=PRE), DIMENSION(3)                         :: coeffs
 
     ! Tabulated data
-    INTEGER,                                  INTENT(IN) :: tabulation_method
+    INTEGER,                                  INTENT(IN) :: tabulation_grid_shape
     REAL(KIND=PRE), DIMENSION(:),             INTENT(IN) :: tabulated_r_range
     REAL(KIND=PRE), DIMENSION(:),             INTENT(IN) :: tabulated_z_range
     REAL(KIND=PRE), DIMENSION(:, :, :, :),    INTENT(IN) :: tabulated_integrals
@@ -197,7 +197,7 @@ CONTAINS
                 (centers_1(I, :),           &
                 quad_points(J, Q, :),       & ! centers_2(J, :),
                 wavenumber,                 &
-                tabulation_method, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
+                tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
                 SP2, VSP2_SYM, VSP2_ANTISYM &
                 )
             ELSE
@@ -206,7 +206,7 @@ CONTAINS
                 quad_points(J, Q, :),       & ! centers_2(J, :),
                 wavenumber,                 &
                 depth,                      &
-                tabulation_method, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
+                tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
                 NEXP, AMBDA, AR,            &
                 SP2, VSP2_SYM, VSP2_ANTISYM &
                 )
@@ -264,7 +264,7 @@ CONTAINS
               (centers_1(I, :),           &
               quad_points(J, 1, :),       & ! centers_2(J, :),
               wavenumber,                 &
-              tabulation_method, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
+              tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
               SP2, VSP2_SYM, VSP2_ANTISYM &
               )
           ELSE
@@ -273,7 +273,7 @@ CONTAINS
               quad_points(J, 1, :),       & ! centers_2(J, :),
               wavenumber,                 &
               depth,                      &
-              tabulation_method, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
+              tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals, &
               NEXP, AMBDA, AR,            &
               SP2, VSP2_SYM, VSP2_ANTISYM &
               )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,8 @@ Internals
 
 * Update test environments used in noxfile and add ``editable_install_requirements.txt``. (:pull:`498`)
 
+* Rename ``tabulation_method`` parameter of :class:`~capytaine.green_functions.Delhommeau` as the more descriptive ``tabulation_grid_shape``, and similarly for internal variables. (:pull:`503`)
+
 -------------------------------
 New in version 2.1 (2024-04-08)
 -------------------------------

--- a/docs/user_manual/resolution.rst
+++ b/docs/user_manual/resolution.rst
@@ -26,8 +26,8 @@ Two of them are available in the present version:
    take the form of a tabulation of these function values for a grid of
    :math:`(r, z)`, precomputed at the initialization of the program. A
    third-order Lagrange polynomial interpolation is employed to obtain the
-   values between the precomputed values. 
-   
+   values between the precomputed values.
+
    In version 1 of Capytaine (as in version 2 of Nemoh), the tabulation ranges
    of :math:`r` and :math:`z` are set as :math:`[0, 100]` with :math:`328`
    discretization values and :math:`[-16, 0]` with :math:`46` discretization
@@ -40,18 +40,18 @@ Two of them are available in the present version:
         gf = cpt.Delhommeau(tabulation_nr=324, tabulation_rmax=100,
                             tabulation_nz=46, tabulation_zmin=-16,
                             tabulation_nb_integration_points=251,
-                            tabulation_method="legacy")
+                            tabulation_grid_shape="legacy")
 
         # Default in Capytaine 2.1
         gf = cpt.Delhommeau(tabulation_nr=676, tabulation_rmax=100,
                             tabulation_nz=372, tabulation_zmin=-251,
                             tabulation_nb_integration_points=1000,
-                            tabulation_method="scaled_nemoh3")
+                            tabulation_grid_shape="scaled_nemoh3")
 
    In version 2.1, the default numbers of :math:`r` and :math:`z` values have
    been increased to :math:`676` and :math:`372`, respectively. While the range
    of :math:`r` is kept the same, the z range has been extended to
-   :math:`[-251, 0]`. The option :code:`tabulation_method` is used to switched
+   :math:`[-251, 0]`. The option :code:`tabulation_grid_shape` is used to switched
    between the new distribution of points inspired by Nemoh version 3 or the
    :code:`"legacy"` approach. The :code:`tabulation_nb_integration_points`
    controls the accuracy of the precomputed tabulation points themselves.
@@ -135,7 +135,7 @@ elevation. However, when only the force on the body is of interest, they can be
 discarded to save space in memory.
 
 The optional argument :code:`method` (default value: :code:`indirect`)
-controls the approach employed to solve for the potential velocity solutions. 
+controls the approach employed to solve for the potential velocity solutions.
 Two methods are implemented including 1) direct method (source-and-dipole formulation),
 and 2) indirect method (source formulation). The direct method appears to be slightly
 more accurate on some test cases but only allows for the computation of the forces

--- a/pytest/test_bem_green_functions.py
+++ b/pytest/test_bem_green_functions.py
@@ -63,8 +63,8 @@ import capytaine as cpt
 
 
 gfs = [
-        cpt.Delhommeau(tabulation_nr=328, tabulation_nz=46, tabulation_nb_integration_points=251, tabulation_method="legacy"),
-        cpt.XieDelhommeau(tabulation_nr=328, tabulation_nz=46, tabulation_nb_integration_points=251, tabulation_method="legacy"),
+        cpt.Delhommeau(tabulation_nr=328, tabulation_nz=46, tabulation_nb_integration_points=251, tabulation_grid_shape="legacy"),
+        cpt.XieDelhommeau(tabulation_nr=328, tabulation_nz=46, tabulation_nb_integration_points=251, tabulation_grid_shape="legacy"),
         ]
 
 def test_compare_tabulations_of_Delhommeau_and_XieDelhommeau():
@@ -94,8 +94,8 @@ def test_symmetry_of_the_green_function_infinite_depth(gf):
     k = 1.0
     xi = np.array([0.0, 0.0, -1.0])
     xj = np.array([1.0, 1.0, -2.0])
-    g1, dg1_sym, dg1_antisym = gf.fortran_core.green_wave.wave_part_infinite_depth(xi, xj, k, gf.tabulation_method_index, gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals)
-    g2, dg2_sym, dg2_antisym = gf.fortran_core.green_wave.wave_part_infinite_depth(xj, xi, k, gf.tabulation_method_index, gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals)
+    g1, dg1_sym, dg1_antisym = gf.fortran_core.green_wave.wave_part_infinite_depth(xi, xj, k, gf.tabulation_grid_shape_index, gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals)
+    g2, dg2_sym, dg2_antisym = gf.fortran_core.green_wave.wave_part_infinite_depth(xj, xi, k, gf.tabulation_grid_shape_index, gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals)
     assert g1 == approx(g2)
     assert dg1_sym == approx(dg2_sym)
     assert dg1_antisym == approx(-dg2_antisym)
@@ -107,8 +107,8 @@ def test_symmetry_of_the_green_function_finite_depth_no_prony(gf):
     depth = 5.0
     xi = np.array([0.0, 0.0, -1.0])
     xj = np.array([1.0, 1.0, -2.0])
-    g1, dg1_sym, dg1_antisym = gf.fortran_core.green_wave.wave_part_finite_depth(xi, xj, k, depth, gf.tabulation_method_index, gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals, np.zeros(1), np.zeros(1), 1)
-    g2, dg2_sym, dg2_antisym = gf.fortran_core.green_wave.wave_part_finite_depth(xj, xi, k, depth, gf.tabulation_method_index, gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals, np.zeros(1), np.zeros(1), 1)
+    g1, dg1_sym, dg1_antisym = gf.fortran_core.green_wave.wave_part_finite_depth(xi, xj, k, depth, gf.tabulation_grid_shape_index, gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals, np.zeros(1), np.zeros(1), 1)
+    g2, dg2_sym, dg2_antisym = gf.fortran_core.green_wave.wave_part_finite_depth(xj, xi, k, depth, gf.tabulation_grid_shape_index, gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals, np.zeros(1), np.zeros(1), 1)
     assert g1 == approx(g2)
     assert dg1_sym == approx(dg2_sym)
     assert dg1_antisym == approx(-dg2_antisym)
@@ -121,8 +121,8 @@ def test_symmetry_of_the_green_function_finite_depth(gf):
     xi = np.array([0.0, 0.0, -1.0])
     xj = np.array([1.0, 1.0, -2.0])
     ambda, a, nexp = gf.fortran_core.old_prony_decomposition.lisc(k*depth*np.tanh(k*depth), k*depth)
-    g1, dg1_sym, dg1_antisym = gf.fortran_core.green_wave.wave_part_finite_depth(xi, xj, k, depth, gf.tabulation_method_index, gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals, ambda, a, 31)
-    g2, dg2_sym, dg2_antisym = gf.fortran_core.green_wave.wave_part_finite_depth(xj, xi, k, depth, gf.tabulation_method_index, gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals, ambda, a, 31)
+    g1, dg1_sym, dg1_antisym = gf.fortran_core.green_wave.wave_part_finite_depth(xi, xj, k, depth, gf.tabulation_grid_shape_index, gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals, ambda, a, 31)
+    g2, dg2_sym, dg2_antisym = gf.fortran_core.green_wave.wave_part_finite_depth(xj, xi, k, depth, gf.tabulation_grid_shape_index, gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals, ambda, a, 31)
     assert g1 == approx(g2)
     assert dg1_sym == approx(dg2_sym)
     assert dg1_antisym == approx(-dg2_antisym)

--- a/pytest/test_bem_green_functions_table_density.py
+++ b/pytest/test_bem_green_functions_table_density.py
@@ -9,7 +9,7 @@ import capytaine as cpt
 #----------------------------------------------------------------------------------#
 gf = cpt.Delhommeau()
 
-legacy_method = gf.fortran_core.delhommeau_integrals.legacy_method
+legacy_grid_shape = gf.fortran_core.delhommeau_integrals.legacy_method
 scaled_nemoh3_method = gf.fortran_core.delhommeau_integrals.scaled_nemoh3_method
 '''
 
@@ -57,7 +57,7 @@ def test_green_functions_r_spacing_legacy_nr(nr):
     """Test default_r_spacing legacy model"""
 
     rmax = 4/3+abs(nr-32)/3
-    rRange = gf.fortran_core.delhommeau_integrals.default_r_spacing(nr, rmax, legacy_method)
+    rRange = gf.fortran_core.delhommeau_integrals.default_r_spacing(nr, rmax, legacy_grid_shape)
 
     r_cal = []
     for i in range(1,nr+1):
@@ -105,4 +105,3 @@ def test_green_functions_r_spacing_Nemoh_nr(nr):
             r_cal.append((rmax-1)/(nr-c)*(i-c)+1)
 
     assert all([abs(a - b) < 1e-4 for a, b in zip(rRange, r_cal)])
-

--- a/pytest/test_bem_green_functions_table_density.py
+++ b/pytest/test_bem_green_functions_table_density.py
@@ -9,8 +9,8 @@ import capytaine as cpt
 #----------------------------------------------------------------------------------#
 gf = cpt.Delhommeau()
 
-legacy_grid_shape = gf.fortran_core.delhommeau_integrals.legacy_method
-scaled_nemoh3_method = gf.fortran_core.delhommeau_integrals.scaled_nemoh3_method
+legacy_grid = gf.fortran_core.delhommeau_integrals.legacy_grid
+scaled_nemoh3_grid = gf.fortran_core.delhommeau_integrals.scaled_nemoh3_grid
 '''
 
 for nr in [1000, 1500, 2000]:
@@ -24,7 +24,7 @@ def test_green_functions_z_spacing_zmin(zmin):
     """Test default_z_spacing"""
 
     nz = 124
-    zRange = gf.fortran_core.delhommeau_integrals.default_z_spacing(nz, zmin, scaled_nemoh3_method)
+    zRange = gf.fortran_core.delhommeau_integrals.default_z_spacing(nz, zmin, scaled_nemoh3_grid)
 
     dz = []
     for i in range(1,len(zRange)):
@@ -40,7 +40,7 @@ nz = [64,124,248]
 def test_green_functions_z_spacing_nz(nz):
     """Test default_z_spacing"""
     zmin = -251
-    zRange = gf.fortran_core.delhommeau_integrals.default_z_spacing(nz,zmin, scaled_nemoh3_method)
+    zRange = gf.fortran_core.delhommeau_integrals.default_z_spacing(nz,zmin, scaled_nemoh3_grid)
 
     dz = []
     for i in range(1,len(zRange)):
@@ -57,7 +57,7 @@ def test_green_functions_r_spacing_legacy_nr(nr):
     """Test default_r_spacing legacy model"""
 
     rmax = 4/3+abs(nr-32)/3
-    rRange = gf.fortran_core.delhommeau_integrals.default_r_spacing(nr, rmax, legacy_grid_shape)
+    rRange = gf.fortran_core.delhommeau_integrals.default_r_spacing(nr, rmax, legacy_grid)
 
     r_cal = []
     for i in range(1,nr+1):
@@ -74,7 +74,7 @@ def test_green_functions_r_spacing_Nemoh_rmax(rmax):
     nr = 676
     c = 81
     r_logSpace = -np.log(10.0**(-10))/(c - 1.0)
-    rRange = gf.fortran_core.delhommeau_integrals.default_r_spacing(nr, rmax, scaled_nemoh3_method)
+    rRange = gf.fortran_core.delhommeau_integrals.default_r_spacing(nr, rmax, scaled_nemoh3_grid)
 
     r_cal = []
     for i in range(1,nr+1):
@@ -95,7 +95,7 @@ def test_green_functions_r_spacing_Nemoh_nr(nr):
     c = round(nr/nr0*81)
     rmax = 100
     r_logSpace = -np.log(10.0**(-10))/(c - 1.0)
-    rRange = gf.fortran_core.delhommeau_integrals.default_r_spacing(nr, rmax, scaled_nemoh3_method)
+    rRange = gf.fortran_core.delhommeau_integrals.default_r_spacing(nr, rmax, scaled_nemoh3_grid)
 
     r_cal = []
     for i in range(1,nr+1):

--- a/pytest/test_bem_solver.py
+++ b/pytest/test_bem_solver.py
@@ -19,10 +19,10 @@ def sphere():
 
 def test_exportable_settings():
     gf = cpt.Delhommeau(tabulation_nr=10, tabulation_nz=10,
-                    tabulation_method="legacy", tabulation_nb_integration_points=50)
+                    tabulation_grid_shape="legacy", tabulation_nb_integration_points=50)
     assert gf.exportable_settings['green_function'] == 'Delhommeau'
     assert gf.exportable_settings['tabulation_nb_integration_points'] == 50
-    assert gf.exportable_settings['tabulation_method'] == "legacy"
+    assert gf.exportable_settings['tabulation_grid_shape'] == "legacy"
     assert gf.exportable_settings['finite_depth_prony_decomposition_method'] == 'fortran'
 
     gf2 = cpt.XieDelhommeau()

--- a/pytest/test_consistency_with_Nemoh_2.py
+++ b/pytest/test_consistency_with_Nemoh_2.py
@@ -14,7 +14,7 @@ from capytaine.post_pro.kochin import compute_kochin
 def nemoh2_solver():
     gf = cpt.Delhommeau(
             tabulation_nr=328, tabulation_nz=46,
-            tabulation_method='legacy', tabulation_nb_integration_points=251
+            tabulation_grid_shape='legacy', tabulation_nb_integration_points=251
             )
     solver = cpt.BEMSolver(
             engine=cpt.BasicMatrixEngine(matrix_cache_size=0),


### PR DESCRIPTION
The term "tabulation_method" is a bit too broad for the actual usage.
The new term "tabulation_grid_shape" is more accurate.