### PR TITLE
Always tabulate only the low_freq wave part.

### DIFF
--- a/capytaine/green_functions/delhommeau.py
+++ b/capytaine/green_functions/delhommeau.py
@@ -175,9 +175,8 @@ class Delhommeau(AbstractGreenFunction):
         tabulation_rmax = float(tabulation_rmax)
         tabulation_zmin = float(tabulation_zmin)
 
-        filename = "tabulation_{}_{}_{}_{}_{}_{}_{}_{}.npz".format(
-            self.floating_point_precision, self.gf_singularities,
-            self.tabulation_grid_shape,
+        filename = "tabulation_{}_{}_{}_{}_{}_{}_{}.npz".format(
+            self.floating_point_precision, self.tabulation_grid_shape,
             tabulation_nr, tabulation_rmax, tabulation_nz, tabulation_zmin,
             tabulation_nb_integration_points
         )
@@ -200,7 +199,6 @@ class Delhommeau(AbstractGreenFunction):
                     )
             self.tabulated_integrals = self.fortran_core.delhommeau_integrals.construct_tabulation(
                     self.tabulated_r_range, self.tabulated_z_range, tabulation_nb_integration_points,
-                    self.gf_singularities_index,
                     )
             LOG.debug("Saving tabulation in %s", filepath)
             np.savez_compressed(

--- a/capytaine/green_functions/libDelhommeau/benchmarks/openmp/benchmark_omp.f90
+++ b/capytaine/green_functions/libDelhommeau/benchmarks/openmp/benchmark_omp.f90
@@ -60,7 +60,7 @@ allocate(K(nb_faces, nb_faces, 1))
 
 tabulated_r(:) = default_r_spacing(tabulation_nr, 100d0, tabulation_grid_shape)
 tabulated_z(:) = default_z_spacing(tabulation_nz, -251d0, tabulation_grid_shape)
-tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, 1000, gf_singularities)
+tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, 1000)
 
 wavenumber = 1.0
 

--- a/capytaine/green_functions/libDelhommeau/benchmarks/profiling/benchmark_profiling.f90
+++ b/capytaine/green_functions/libDelhommeau/benchmarks/profiling/benchmark_profiling.f90
@@ -60,7 +60,7 @@ allocate(K(nb_faces, nb_faces, 1))
 
 tabulated_r(:) = default_r_spacing(tabulation_nr, 100d0, tabulation_grid_shape)
 tabulated_z(:) = default_z_spacing(tabulation_nz, -251d0, tabulation_grid_shape)
-tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, 1000, gf_singularities)
+tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, 1000)
 
 wavenumber = 1.0
 

--- a/capytaine/green_functions/libDelhommeau/benchmarks/tabulations/benchmark_tabulation.f90
+++ b/capytaine/green_functions/libDelhommeau/benchmarks/tabulations/benchmark_tabulation.f90
@@ -13,8 +13,6 @@ integer :: i_tabulation
 integer, dimension(n_tabulation) :: tabulation_nr
 integer, dimension(n_tabulation) :: tabulation_nz
 
-integer, parameter :: gf_singularities = 0  ! high_freq
-
 
 integer(kind=8) :: starting_time, final_time, clock_rate, clock_rate_in_ns
 
@@ -40,7 +38,7 @@ z = -10*z
 
 call system_clock(starting_time)
 do i_sample = 1, n_samples
-    integrals(i_sample, :, :) = numerical_integration(r(i_sample), z(i_sample), 2500, gf_singularities)
+    integrals(i_sample, :, :) = numerical_integration(r(i_sample), z(i_sample), 2500)
 enddo
 call system_clock(final_time)
 print*, "Integration (fine)  :", (final_time - starting_time)/clock_rate_in_ns/n_samples, " ns"
@@ -48,7 +46,7 @@ print*, "Integration (fine)  :", (final_time - starting_time)/clock_rate_in_ns/n
 
 call system_clock(starting_time)
 do i_sample = 1, n_samples
-    integrals(i_sample, :, :) = numerical_integration(r(i_sample), z(i_sample), 251, gf_singularities)
+    integrals(i_sample, :, :) = numerical_integration(r(i_sample), z(i_sample), 251)
 enddo
 call system_clock(final_time)
 print*, "Integration (coarse):", (final_time - starting_time)/clock_rate_in_ns/n_samples, " ns"
@@ -65,7 +63,7 @@ do i_tabulation = 1, n_tabulation
 
   tabulated_r(:) = default_r_spacing(tabulation_nr(i_tabulation), 100d0, tabulation_grid_shape)
   tabulated_z(:) = default_z_spacing(tabulation_nz(i_tabulation), -251d0, tabulation_grid_shape)
-  tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, 1000, gf_singularities)
+  tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, 1000)
 
   call system_clock(starting_time)
   do i_sample = 1, n_samples

--- a/capytaine/green_functions/libDelhommeau/examples/minimal/minimal_example.f90
+++ b/capytaine/green_functions/libDelhommeau/examples/minimal/minimal_example.f90
@@ -51,7 +51,7 @@ program test
 
   tabulated_r(:) = default_r_spacing(tabulation_nr, 100d0, tabulation_grid_shape)
   tabulated_z(:) = default_z_spacing(tabulation_nz, -251d0, tabulation_grid_shape)
-  tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, 1000, gf_singularities)
+  tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, 1000)
 
   depth = ieee_value(depth, ieee_positive_inf)
 

--- a/capytaine/green_functions/libDelhommeau/src/Delhommeau_integrals.f90
+++ b/capytaine/green_functions/libDelhommeau/src/Delhommeau_integrals.f90
@@ -1,10 +1,10 @@
-! Copyright (C) 2022 Matthieu Ancellin
-! See LICENSE file at <https://github.com/mancellin/capytaine>
+! Copyright (C) 2022-2024 Matthieu Ancellin
+! See LICENSE file at <https://github.com/capytaine/capytaine>
 !
 ! This module contains functions to evaluate the following integrals
 ! D1 = Re[ ∫(-i cosθ)(J(ζ) - 1/ζ)dθ ]
 ! D2 = Re[ ∫(-i cosθ)(e^ζ)dθ ]
-! Z1 = Re[ ∫(J(ζ))dθ ]
+! Z1 = Re[ ∫(J(ζ))dθ ]  ! That is G^+, the low_freq version.
 ! Z2 = Re[ ∫(e^ζ)dθ ]
 ! where ζ depends on θ, as well as two additional parameters `r ∈ [0, +∞)` and `z ∈ (-∞, 0]`.
 !
@@ -141,6 +141,7 @@ contains
   pure function asymptotic_approximations(r, z) result(integrals)
     ! Evaluate the wave part of legacy's Delhommeau Green function
     ! using an approximate expression for large r and |z|
+    ! This always is G^-, that is not exactly the same as `numerical_integration`
     real(kind=pre), intent(in) :: r
     real(kind=pre), intent(in) :: z
 

--- a/capytaine/green_functions/libDelhommeau/src/Delhommeau_integrals.f90
+++ b/capytaine/green_functions/libDelhommeau/src/Delhommeau_integrals.f90
@@ -4,11 +4,7 @@
 ! This module contains functions to evaluate the following integrals
 ! D1 = Re[ ∫(-i cosθ)(J(ζ) - 1/ζ)dθ ]
 ! D2 = Re[ ∫(-i cosθ)(e^ζ)dθ ]
-! if (gf_singularities == HIGH_FREQ)
-!   Z1 = Re[ ∫(J(ζ) - 1/ζ)dθ ]
-! else
-!   Z1 = Re[ ∫(J(ζ))dθ ]
-! endif
+! Z1 = Re[ ∫(J(ζ))dθ ]
 ! Z2 = Re[ ∫(e^ζ)dθ ]
 ! where ζ depends on θ, as well as two additional parameters `r ∈ [0, +∞)` and `z ∈ (-∞, 0]`.
 !
@@ -37,14 +33,13 @@ module delhommeau_integrals
 
 contains
 
-  pure function numerical_integration(r, z, n, gf_singularities) result(integrals)
+  pure function numerical_integration(r, z, n) result(integrals)
     ! Compute the integrals by numerical integration, with `nb_integration_points` points.
 
     ! input
     real(kind=pre), intent(in) :: r
     real(kind=pre), intent(in) :: z
     integer,        intent(in) :: n ! nb_integration_points
-    integer,        intent(in) :: gf_singularities
 
     ! output
     real(kind=pre), dimension(2, 2) :: integrals
@@ -80,11 +75,7 @@ contains
       jzeta = exp_e1(zeta) + ii*pi*exp_zeta
       integrals(1, 1) = integrals(1, 1) + delta_theta * cos_theta * aimag(jzeta - 1.0/zeta)
       integrals(2, 1) = integrals(2, 1) + delta_theta * cos_theta * aimag(exp_zeta)
-      if (gf_singularities == HIGH_FREQ) then
-        integrals(1, 2) = integrals(1, 2) + delta_theta * real(jzeta - 1.0/zeta)
-      elseif (gf_singularities == LOW_FREQ) then
-        integrals(1, 2) = integrals(1, 2) + delta_theta * real(jzeta)
-      endif
+      integrals(1, 2) = integrals(1, 2) + delta_theta * real(jzeta)
       integrals(2, 2) = integrals(2, 2) + delta_theta * real(exp_zeta)
     enddo
 
@@ -147,13 +138,11 @@ contains
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  pure function asymptotic_approximations(r, z, gf_singularities) result(integrals)
+  pure function asymptotic_approximations(r, z) result(integrals)
     ! Evaluate the wave part of legacy's Delhommeau Green function
     ! using an approximate expression for large r and |z|
     real(kind=pre), intent(in) :: r
     real(kind=pre), intent(in) :: z
-
-    integer, intent(in) :: gf_singularities
 
     real(kind=pre), dimension(2, 2) :: integrals
 
@@ -170,28 +159,23 @@ contains
     integrals(1, 2) = -expz_sqr*sin_kr + z/r1**3
     integrals(2, 2) =  expz_sqr*cos_kr
     integrals(:, :) = 2*integrals(:, :)
-    if (gf_singularities == LOW_FREQ) then
-      ! correction to retrieve G^+ instead of G^-
-      integrals(1, 2) = integrals(1, 2) - 2/r1
-    endif
 
   end function asymptotic_approximations
 
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  pure function construct_tabulation(r_range, z_range, nb_integration_points, gf_singularities) result(tabulation)
+  pure function construct_tabulation(r_range, z_range, nb_integration_points) result(tabulation)
     real(kind=pre), dimension(:), intent(in) :: r_range
     real(kind=pre), dimension(:), intent(in) :: z_range
     integer,        intent(in) :: nb_integration_points
-    integer,        intent(in) :: gf_singularities
     real(kind=pre), dimension(size(r_range), size(z_range), 2, 2) :: tabulation
 
     integer :: i, j
 
     do concurrent (j = 1:size(z_range))
       do concurrent (i = 1:size(r_range))
-        tabulation(i, j, :, :) = numerical_integration(r_range(i), z_range(j), nb_integration_points, gf_singularities)
+        tabulation(i, j, :, :) = numerical_integration(r_range(i), z_range(j), nb_integration_points)
       enddo
     enddo
 

--- a/capytaine/green_functions/libDelhommeau/src/Green_wave.f90
+++ b/capytaine/green_functions/libDelhommeau/src/Green_wave.f90
@@ -72,7 +72,12 @@ CONTAINS
     !=======================================================
     IF ((size(tabulated_z_range) <= 1) .or. (size(tabulated_r_range) <= 1)) THEN
       ! No tabulation, fully recompute the Green function each time.
-      integrals = numerical_integration(r, z, 500, gf_singularities)
+      integrals = numerical_integration(r, z, 500)
+      if (gf_singularities == HIGH_FREQ) then
+        ! numerical_integration always computes the low_freq version,
+        ! so need a fix to get the high_freq
+        integrals(1, 2) = integrals(1, 2) + 2/r1
+      endif
     ELSE
       IF ((abs(z) < abs(tabulated_z_range(size(tabulated_z_range)))) &
           .AND. (r < tabulated_r_range(size(tabulated_r_range)))) THEN
@@ -80,10 +85,19 @@ CONTAINS
         integrals = pick_in_default_tabulation( &
             r, z, tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals &
         )
-        ! The tabulated data are expected to have been built with the correct setting of 'gf_singularities'
+        if (gf_singularities == HIGH_FREQ) then
+          ! numerical_integration always computes the low_freq version,
+          ! so need a fix to get the high_freq
+          integrals(1, 2) = integrals(1, 2) + 2/r1
+        endif
       ELSE
         ! Delhommeau's asymptotic expression of Green function for distant panels
-        integrals = asymptotic_approximations(MAX(r, 1e-10), z, gf_singularities)
+        integrals = asymptotic_approximations(MAX(r, 1e-10), z)
+        if (gf_singularities == LOW_FREQ) then
+          ! numerical_integration always computes the high_freq version,
+          ! so need a fix to get the low_freq
+          integrals(1, 2) = integrals(1, 2) - 2/r1
+        endif
       ENDIF
     ENDIF
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,8 @@ Internals
 
 * The compiled Fortran extension is not split into a ``Delhommeau`` and a ``XieDelhommeau`` version anymore. The computation of the latter can be achieved by the run-time parameter ``gf_singularities`` of the class :class:`~capytaine.green_functions.delhommeau.Delhommeau` class. The class :class:`~capytaine.green_functions.delhommeau.XieDelhommeau` is kept for backward compatibility (:pull:`475`).
 
+* The tabulation is always the tabulation of the ``low_freq`` wave part (formerly ``XieDelhommeau``) to simplify the implementation (:pull:`508`).
+
 -------------------------------
 New in version 2.1 (2024-04-08)
 -------------------------------

--- a/pytest/test_bem_green_functions.py
+++ b/pytest/test_bem_green_functions.py
@@ -65,27 +65,6 @@ gfs = [
         cpt.XieDelhommeau(tabulation_nr=328, tabulation_nz=46, tabulation_nb_integration_points=251, tabulation_grid_shape="legacy"),
         ]
 
-def test_compare_tabulations_of_Delhommeau_and_XieDelhommeau():
-    assert np.allclose(gfs[0].tabulated_integrals[:, :, 0, 0],
-                       gfs[1].tabulated_integrals[:, :, 0, 0])
-    assert np.allclose(gfs[0].tabulated_integrals[:, :, 1, 0],
-                       gfs[1].tabulated_integrals[:, :, 1, 0])
-    assert np.allclose(gfs[0].tabulated_integrals[:, :, 1, 1],
-                       gfs[1].tabulated_integrals[:, :, 1, 1])
-
-    r_range = gfs[0].tabulated_r_range
-    z_range = gfs[0].tabulated_z_range
-
-    # Make 2D arrays
-    r = r_range[:, None] * np.ones_like(z_range)[None, :]
-    z = np.ones_like(r_range)[:, None] * z_range[None, :]
-    R1 = np.hypot(r, z)
-
-    # Compare Z1, for great values of Z, where both methods are as accurate
-    Del = gfs[0].tabulated_integrals[:, :, 0, 1] - 2/R1
-    Xie = gfs[1].tabulated_integrals[:, :, 0, 1]
-    assert np.allclose(Del[abs(z) > 1], Xie[abs(z) > 1], atol=1e-3)
-
 
 @pytest.mark.parametrize("gf", gfs)
 def test_symmetry_of_the_green_function_infinite_depth(gf):

--- a/pytest/test_consistency_with_Nemoh_2.py
+++ b/pytest/test_consistency_with_Nemoh_2.py
@@ -92,7 +92,7 @@ def test_floating_sphere_finite_freq(nemoh2_solver):
              [-0.7986111E-03+0.4840984E-02j, 0.5733186E-02-0.2179381E-02j, 0.9460891E-03-0.7079404E-02j, 0.5733187E-02-0.2179380E-02j, -0.7986113E-03+0.4840984E-02j],
              [-0.4340803E-02-0.4742807E-03j, -0.7986111E-03+0.4840984E-02j, 0.2214827E-02+0.4700643E-02j, -0.7986113E-03+0.4840983E-02j, -0.4340803E-02-0.4742809E-03j]]
         )
-    assert np.allclose(eta/(-1j*problem.omega), ref, rtol=1e-4)
+    assert np.allclose(eta/(-1j*problem.omega), ref, rtol=1e-2)
 
     # omega = 1, diffraction
     problem = cpt.DiffractionProblem(body=sphere, omega=1.0, water_depth=np.inf)
@@ -167,13 +167,13 @@ def test_floating_sphere_finite_depth(nemoh2_solver):
     # omega = 2, radiation
     problem = cpt.RadiationProblem(body=sphere, omega=2.0, radiating_dof="Heave", water_depth=10.0)
     result = nemoh2_solver.solve(problem)
-    assert np.isclose(result.added_masses["Heave"],       1375.0, atol=1e-3*sphere.volume*problem.rho)
-    assert np.isclose(result.radiation_dampings["Heave"], 1418.0, atol=1e-3*sphere.volume*problem.rho)
+    assert np.isclose(result.added_masses["Heave"],       1375.0, atol=1e-2*sphere.volume*problem.rho)
+    assert np.isclose(result.radiation_dampings["Heave"], 1418.0, atol=1e-2*sphere.volume*problem.rho)
 
     # omega = 2, diffraction
     problem = cpt.DiffractionProblem(body=sphere, omega=2.0, wave_direction=0.0, water_depth=10.0)
     result = nemoh2_solver.solve(problem)
-    assert np.isclose(result.forces["Heave"], 5872.8 * np.exp(-2.627j), rtol=1e-3)
+    assert np.isclose(result.forces["Heave"], 5872.8 * np.exp(-2.627j), rtol=1e-2)
 
 
 def test_two_distant_spheres_in_finite_depth(nemoh2_solver):
@@ -191,7 +191,7 @@ def test_two_distant_spheres_in_finite_depth(nemoh2_solver):
 
     total_volume = 2*4/3*np.pi*radius**3
     assert np.isclose(result.added_masses['Surge'], 124.0, atol=1e-3*total_volume*problem.rho)
-    assert np.isclose(result.radiation_dampings['Surge'], 913.3, atol=1e-3*total_volume*problem.rho)
+    assert np.isclose(result.radiation_dampings['Surge'], 913.3, atol=1e-2*total_volume*problem.rho)
 
 
 def test_multibody(nemoh2_solver):


### PR DESCRIPTION
Keep a single variant to make the implementation simpler. The low_freq one is expected to be slightly more accurate. At the cost of a slight loss of consistency with Nemoh 2.