### PR TITLE
Remove mesh resolution warning for infinite frequency

### DIFF
--- a/capytaine/bem/solver.py
+++ b/capytaine/bem/solver.py
@@ -188,7 +188,7 @@ class BEMSolver:
         """Display a warning if some of the problems have a mesh resolution
         that might not be sufficient for the given wavelength."""
         risky_problems = [pb for pb in problems
-                          if pb.wavelength < pb.body.minimal_computable_wavelength]
+                          if 0.0 < pb.wavelength < pb.body.minimal_computable_wavelength]
         nb_risky_problems = len(risky_problems)
         if nb_risky_problems == 1:
             pb = risky_problems[0]

--- a/capytaine/tools/symbolic_multiplication.py
+++ b/capytaine/tools/symbolic_multiplication.py
@@ -1,7 +1,7 @@
 import numpy as np
-from functools import wraps
+from functools import wraps, total_ordering
 
-# @total_ordering
+@total_ordering
 class SymbolicMultiplication:
     def __init__(self, symbol, value=1.0):
         self.symbol = symbol

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,11 @@ Major changes
 
 * Experimental support for panels on the free surface. (:pull:`419`)
 
+Minor changes
+~~~~~~~~~~~~~
+
+* Remove mesh resolution warning when the frequency is infinite (or the wavelength is zero) (:pull:`511`).
+
 Internals
 ~~~~~~~~~
 

--- a/pytest/test_bem_solver.py
+++ b/pytest/test_bem_solver.py
@@ -142,6 +142,20 @@ def test_fill_dataset(sphere):
     # wavenumbers = wavenumber_data_array(results)
     # assert isinstance(wavenumbers, xr.DataArray)
 
+def test_warning_mesh_resolution(sphere, caplog):
+    solver = cpt.BEMSolver()
+    pb = cpt.RadiationProblem(body=sphere, wavelength=0.1*sphere.minimal_computable_wavelength)
+    with caplog.at_level("WARNING"):
+        solver.solve(pb)
+    assert "resolution " in caplog.text
+
+def test_no_warning_mesh_resolution_at_zero_wavelength(sphere, caplog):
+    solver = cpt.BEMSolver()
+    pb = cpt.RadiationProblem(body=sphere, wavelength=0)
+    with caplog.at_level("WARNING"):
+        solver.solve(pb)
+    assert "resolution " not in caplog.text
+
 #-----------------------------------------------------------------------------#
 # Test direct solver
 #-----------------------------------------------------------------------------#


### PR DESCRIPTION
Actually, the warning might not be relevant above some high frequency, but I don't know which it is.