### PR TITLE
refactor: tabulate both low_freq and high_freq variants

### DIFF
--- a/capytaine/green_functions/delhommeau.py
+++ b/capytaine/green_functions/delhommeau.py
@@ -86,7 +86,7 @@ class Delhommeau(AbstractGreenFunction):
     tabulated_r_range: numpy.array of shape (tabulation_nr,) and type floating_point_precision
     tabulated_z_range: numpy.array of shape (tabulation_nz,) and type floating_point_precision
         Coordinates of the tabulation points.
-    tabulated_integrals: numpy.array of shape (tabulation_nr, tabulation_nz, 2, 2) and type floating_point_precision
+    tabulated_integrals: numpy.array of shape (tabulation_nr, tabulation_nz, nb_tabulated_values) and type floating_point_precision
         Tabulated Delhommeau integrals.
     """
 

--- a/capytaine/green_functions/libDelhommeau/Makefile
+++ b/capytaine/green_functions/libDelhommeau/Makefile
@@ -71,7 +71,7 @@ BENCH_BIN=$(BENCH_SRC:.f90=.bin)
 ### ==============================================
 ### targets
 
-.PHONY: clean mrproper
+.PHONY: .init clean mrproper
 
 $(OBJDIR)/%.o: %.f90
 	$(COMP) $(FLAGS) -J$(OBJDIR) -c $< -o $@

--- a/capytaine/green_functions/libDelhommeau/benchmarks/openmp/benchmark_omp.f90
+++ b/capytaine/green_functions/libDelhommeau/benchmarks/openmp/benchmark_omp.f90
@@ -6,6 +6,7 @@ use ieee_arithmetic
 use matrices, only: build_matrices
 use delhommeau_integrals, only: default_r_spacing, default_z_spacing, construct_tabulation
 use constants, only: pre  ! Floating point precision
+use constants, only: nb_tabulated_values
 use old_prony_decomposition, only: lisc
 
 implicit none
@@ -35,7 +36,7 @@ integer, parameter :: tabulation_nr = 328
 integer, parameter :: tabulation_nz = 46
 real(kind=pre), dimension(tabulation_nr)                       :: tabulated_r
 real(kind=pre), dimension(tabulation_nz)                       :: tabulated_z
-real(kind=pre), dimension(tabulation_nr, tabulation_nz, 2, 2)  :: tabulated_integrals
+real(kind=pre), dimension(tabulation_nr, tabulation_nz, nb_tabulated_values)  :: tabulated_integrals
 
 integer, parameter :: gf_singularities = 0  ! high_freq
 
@@ -61,7 +62,7 @@ allocate(K(nb_faces, nb_faces, 1))
 
 tabulated_r(:) = default_r_spacing(tabulation_nr, 100d0, tabulation_grid_shape)
 tabulated_z(:) = default_z_spacing(tabulation_nz, -251d0, tabulation_grid_shape)
-tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, tabulation_nb_integration_points)
+tabulated_integrals(:, :, :) = construct_tabulation(tabulated_r, tabulated_z, tabulation_nb_integration_points)
 
 wavenumber = 1.0
 

--- a/capytaine/green_functions/libDelhommeau/benchmarks/profiling/benchmark_profiling.f90
+++ b/capytaine/green_functions/libDelhommeau/benchmarks/profiling/benchmark_profiling.f90
@@ -6,6 +6,7 @@ use ieee_arithmetic
 use matrices, only: build_matrices
 use delhommeau_integrals, only: default_r_spacing, default_z_spacing, construct_tabulation
 use constants, only: pre  ! Floating point precision
+use constants, only: nb_tabulated_values
 use old_prony_decomposition, only: lisc
 
 implicit none
@@ -35,7 +36,7 @@ integer, parameter :: tabulation_nr = 676
 integer, parameter :: tabulation_nz = 372
 real(kind=pre), dimension(tabulation_nr)                       :: tabulated_r
 real(kind=pre), dimension(tabulation_nz)                       :: tabulated_z
-real(kind=pre), dimension(tabulation_nr, tabulation_nz, 2, 2)  :: tabulated_integrals
+real(kind=pre), dimension(tabulation_nr, tabulation_nz, nb_tabulated_values)  :: tabulated_integrals
 
 integer, parameter :: gf_singularities = 0
 
@@ -61,7 +62,7 @@ allocate(K(nb_faces, nb_faces, 1))
 
 tabulated_r(:) = default_r_spacing(tabulation_nr, 100d0, tabulation_grid_shape)
 tabulated_z(:) = default_z_spacing(tabulation_nz, -251d0, tabulation_grid_shape)
-tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, tabulation_nb_integration_points)
+tabulated_integrals(:, :, :) = construct_tabulation(tabulated_r, tabulated_z, tabulation_nb_integration_points)
 
 wavenumber = 1.0
 

--- a/capytaine/green_functions/libDelhommeau/benchmarks/tabulations/benchmark_tabulation.f90
+++ b/capytaine/green_functions/libDelhommeau/benchmarks/tabulations/benchmark_tabulation.f90
@@ -1,6 +1,7 @@
 program benchmark_tabulation
 
 use constants, only: pre  ! Floating point precision
+use constants, only: nb_tabulated_values
 use delhommeau_integrals
 
 implicit none
@@ -17,8 +18,8 @@ integer, dimension(n_tabulation) :: tabulation_nz
 integer(kind=8) :: starting_time, final_time, clock_rate, clock_rate_in_ns
 
 real(kind=pre), dimension(:), allocatable          :: r, z, tabulated_r, tabulated_z
-real(kind=pre), dimension(:, :, :, :), allocatable :: tabulated_integrals
-real(kind=pre), dimension(:, :, :), allocatable    :: integrals
+real(kind=pre), dimension(:, :, :), allocatable    :: tabulated_integrals
+real(kind=pre), dimension(:, :), allocatable       :: integrals
 
 print*, "-- Run libdelhommeau/benchmark/tabulations/benchmark_tabulation.f90"
 
@@ -27,7 +28,7 @@ clock_rate_in_ns = clock_rate / 1000000000
 
 allocate(r(n_samples))
 allocate(z(n_samples))
-allocate(integrals(n_samples, 2, 2))
+allocate(integrals(n_samples, nb_tabulated_values))
 
 call random_number(r)
 r = 100*r
@@ -38,7 +39,7 @@ z = -10*z
 
 call system_clock(starting_time)
 do i_sample = 1, n_samples
-    integrals(i_sample, :, :) = numerical_integration(r(i_sample), z(i_sample), 2501)
+    integrals(i_sample, :) = numerical_integration(r(i_sample), z(i_sample), 2501)
 enddo
 call system_clock(final_time)
 print*, "Integration (fine)  :", (final_time - starting_time)/clock_rate_in_ns/n_samples, " ns"
@@ -46,7 +47,7 @@ print*, "Integration (fine)  :", (final_time - starting_time)/clock_rate_in_ns/n
 
 call system_clock(starting_time)
 do i_sample = 1, n_samples
-    integrals(i_sample, :, :) = numerical_integration(r(i_sample), z(i_sample), 251)
+    integrals(i_sample, :) = numerical_integration(r(i_sample), z(i_sample), 251)
 enddo
 call system_clock(final_time)
 print*, "Integration (coarse):", (final_time - starting_time)/clock_rate_in_ns/n_samples, " ns"
@@ -59,15 +60,15 @@ do i_tabulation = 1, n_tabulation
 
   allocate(tabulated_r(tabulation_nr(i_tabulation)))
   allocate(tabulated_z(tabulation_nz(i_tabulation)))
-  allocate(tabulated_integrals(tabulation_nr(i_tabulation), tabulation_nz(i_tabulation), 2, 2))
+  allocate(tabulated_integrals(tabulation_nr(i_tabulation), tabulation_nz(i_tabulation), nb_tabulated_values))
 
   tabulated_r(:) = default_r_spacing(tabulation_nr(i_tabulation), 100d0, tabulation_grid_shape)
   tabulated_z(:) = default_z_spacing(tabulation_nz(i_tabulation), -251d0, tabulation_grid_shape)
-  tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, 1001)
+  tabulated_integrals(:, :, :) = construct_tabulation(tabulated_r, tabulated_z, 1001)
 
   call system_clock(starting_time)
   do i_sample = 1, n_samples
-      integrals(i_sample, :, :) = pick_in_default_tabulation(r(i_sample), z(i_sample), &
+      integrals(i_sample, :) = pick_in_default_tabulation(r(i_sample), z(i_sample), &
         tabulation_grid_shape, tabulated_r, tabulated_z, tabulated_integrals)
   enddo
   call system_clock(final_time)
@@ -80,7 +81,7 @@ enddo
 
 call system_clock(starting_time)
 do i_sample = 1, n_samples
-    integrals(i_sample, :, :) = asymptotic_approximations(r(i_sample), z(i_sample))
+    integrals(i_sample, :) = asymptotic_approximations(r(i_sample), z(i_sample))
 enddo
 call system_clock(final_time)
 print*, "Asymptotic          :", (final_time - starting_time)/clock_rate_in_ns/n_samples, " ns"

--- a/capytaine/green_functions/libDelhommeau/examples/minimal/minimal_example.f90
+++ b/capytaine/green_functions/libDelhommeau/examples/minimal/minimal_example.f90
@@ -5,7 +5,7 @@ program test
   use matrices, only: build_matrices, is_infinity
   use delhommeau_integrals, only: default_r_spacing, default_z_spacing, construct_tabulation
   use floating_point_precision, only: pre
-  use constants, only: zero
+  use constants, only: zero, nb_tabulated_values
   use old_prony_decomposition, only: lisc
 
   implicit none
@@ -28,12 +28,12 @@ program test
 
   ! Tabulation of the integrals used in the Green function
   integer, parameter :: tabulation_grid_shape = 1   ! scaled_nemoh3 method
-  integer, parameter :: tabulation_nb_integration_points = 1000
+  integer, parameter :: tabulation_nb_integration_points = 251
   integer, parameter :: tabulation_nr = 676
   integer, parameter :: tabulation_nz = 372
-  real(kind=pre), dimension(tabulation_nr)                       :: tabulated_r
-  real(kind=pre), dimension(tabulation_nz)                       :: tabulated_z
-  real(kind=pre), dimension(tabulation_nr, tabulation_nz, 2, 2)  :: tabulated_integrals
+  real(kind=pre), dimension(tabulation_nr)         :: tabulated_r
+  real(kind=pre), dimension(tabulation_nz)         :: tabulated_z
+  real(kind=pre), allocatable, dimension(:, :, :)  :: tabulated_integrals
 
   integer, parameter :: gf_singularities = 0  ! high_freq
 
@@ -52,7 +52,8 @@ program test
 
   tabulated_r(:) = default_r_spacing(tabulation_nr, 100d0, tabulation_grid_shape)
   tabulated_z(:) = default_z_spacing(tabulation_nz, -251d0, tabulation_grid_shape)
-  tabulated_integrals(:, :, :, :) = construct_tabulation(tabulated_r, tabulated_z, tabulation_nb_integration_points)
+  allocate(tabulated_integrals(tabulation_nr, tabulation_nz, nb_tabulated_values))
+  tabulated_integrals = construct_tabulation(tabulated_r, tabulated_z, tabulation_nb_integration_points)
 
   depth = ieee_value(depth, ieee_positive_inf)
 

--- a/capytaine/green_functions/libDelhommeau/src/Delhommeau_integrals.f90
+++ b/capytaine/green_functions/libDelhommeau/src/Delhommeau_integrals.f90
@@ -3,11 +3,11 @@
 !
 ! This module contains functions to evaluate the following integrals
 ! for a given range of values of `r ∈ [0, +∞)` and `z ∈ (-∞, 0]`.
-! tab(1) = Re[ 𝒢^+ ] = 2/π Re[ ∫ e^ζ (E(ζ) + iπ) dθ ]
-! tab(2) = Re[ 𝒢^- ] = 2/π Re[ ∫ (e^ζ (E(ζ) + iπ) - 1/ζ) dθ ]
-! tab(3) = Im[ 𝒢^+ ] = Im[ 𝒢^- ] =  2/π Re[ ∫(e^ζ) dθ ]
-! tab(4) = Re[ ∂𝒢^+/∂r ] = 2 Re[ ∫ (i cosθ) (e^ζ (E(ζ) + iπ) - 1/ζ) dθ ]
-! tab(5) = Im[ ∂𝒢^+/∂r ] = 2 Re[ ∫ (i cosθ) (e^ζ) dθ ]
+! I(1) = Re[ 𝒢^+ ] = 2/π Re[ ∫ e^ζ (E(ζ) + iπ) dθ ]
+! I(2) = Re[ 𝒢^- ] = 2/π Re[ ∫ (e^ζ (E(ζ) + iπ) - 1/ζ) dθ ]
+! I(3) = Im[ 𝒢^+ ] = Im[ 𝒢^- ] =  2/π Re[ ∫(e^ζ) dθ ]
+! I(4) = Re[ ∂𝒢^+/∂r ] = 2 Re[ ∫ (i cosθ) (e^ζ (E(ζ) + iπ) - 1/ζ) dθ ]
+! I(5) = Im[ ∂𝒢^+/∂r ] = 2 Re[ ∫ (i cosθ) (e^ζ) dθ ]
 ! where ζ = z + i r cos θ.
 !
 ! They are required for the evaluation of the Green function and its gradient.

--- a/capytaine/green_functions/libDelhommeau/src/Green_wave.f90
+++ b/capytaine/green_functions/libDelhommeau/src/Green_wave.f90
@@ -52,7 +52,7 @@ CONTAINS
     integer,                               intent(in) :: tabulation_grid_shape
     real(kind=pre), dimension(:),          intent(in) :: tabulated_r_range
     real(kind=pre), dimension(:),          intent(in) :: tabulated_z_range
-    real(kind=pre), dimension(:, :, :, :), intent(in) :: tabulated_integrals
+    real(kind=pre), dimension(:, :, :),    intent(in) :: tabulated_integrals
     integer,                               intent(in) :: nexp
     real(kind=pre), dimension(nexp),       intent(in) :: ambda, ar
 
@@ -166,8 +166,8 @@ CONTAINS
       tabulated_r_range, tabulated_z_range, tabulated_integrals, &
       gf_singularities,                                          &
       G, nablaG)
-      ! Returns (G^-, nabla G^+) if gf_singularities == HIGH_FREQ
-      ! and (G^+, nabla G^+) if gf_singularities == LOW_FREQ
+      ! Returns (k G^-, k nabla G^-) if gf_singularities == HIGH_FREQ
+      ! and (k G^+, k nabla G^+) if gf_singularities == LOW_FREQ
 
     ! Inputs
     REAL(KIND=PRE), DIMENSION(3),             INTENT(IN) :: X0I, X0J
@@ -179,7 +179,7 @@ CONTAINS
     INTEGER,                                  INTENT(IN) :: tabulation_grid_shape
     REAL(KIND=PRE), DIMENSION(:),             INTENT(IN) :: tabulated_r_range
     REAL(KIND=PRE), DIMENSION(:),             INTENT(IN) :: tabulated_z_range
-    REAL(KIND=PRE), DIMENSION(size(tabulated_r_range), size(tabulated_z_range), 2, 2), INTENT(IN) :: tabulated_integrals
+    REAL(KIND=PRE), DIMENSION(:, :, :),       INTENT(IN) :: tabulated_integrals
 
     ! Outputs
     COMPLEX(KIND=PRE),                        INTENT(OUT) :: G
@@ -187,7 +187,8 @@ CONTAINS
 
     ! Local variables
     REAL(KIND=PRE) :: r, r1, z, drdx1, drdx2, dzdx3
-    REAL(KIND=PRE), dimension(2, 2) :: integrals
+    complex(kind=pre) :: dGdr
+    REAL(KIND=PRE), dimension(nb_tabulated_values) :: integrals
 
     r = wavenumber * NORM2(X0I(1:2) - X0J(1:2))
     z = wavenumber * (X0I(3) + X0J(3))
@@ -199,11 +200,6 @@ CONTAINS
     IF ((size(tabulated_z_range) <= 1) .or. (size(tabulated_r_range) <= 1)) THEN
       ! No tabulation, fully recompute the Green function each time.
       integrals = numerical_integration(r, z, tabulation_nb_integration_points)
-      if (gf_singularities == HIGH_FREQ) then
-        ! numerical_integration always computes the low_freq version,
-        ! so need a fix to get the high_freq
-        integrals(1, 2) = integrals(1, 2) + 2/r1
-      endif
     ELSE
       IF ((abs(z) < abs(tabulated_z_range(size(tabulated_z_range)))) &
           .AND. (r < tabulated_r_range(size(tabulated_r_range)))) THEN
@@ -211,19 +207,9 @@ CONTAINS
         integrals = pick_in_default_tabulation( &
             r, z, tabulation_grid_shape, tabulated_r_range, tabulated_z_range, tabulated_integrals &
         )
-        if (gf_singularities == HIGH_FREQ) then
-          ! numerical_integration always computes the low_freq version,
-          ! so need a fix to get the high_freq
-          integrals(1, 2) = integrals(1, 2) + 2/r1
-        endif
       ELSE
         ! Delhommeau's asymptotic expression of Green function for distant panels
         integrals = asymptotic_approximations(MAX(r, 1e-10), z)
-        if (gf_singularities == LOW_FREQ) then
-          ! numerical_integration always computes the high_freq version,
-          ! so need a fix to get the low_freq
-          integrals(1, 2) = integrals(1, 2) - 2/r1
-        endif
       ENDIF
     ENDIF
 
@@ -241,20 +227,20 @@ CONTAINS
     END IF
     dzdx3 = wavenumber
 
-    G    = CMPLX(integrals(1, 2), integrals(2, 2), KIND=PRE)
-    nablaG(1) = drdx1 * CMPLX(integrals(1, 1), integrals(2, 1), KIND=PRE)
-    nablaG(2) = drdx2 * CMPLX(integrals(1, 1), integrals(2, 1), KIND=PRE)
-    nablaG(3) = dzdx3 * CMPLX(integrals(1, 2), integrals(2, 2), KIND=PRE)
-
     if (gf_singularities == LOW_FREQ) then
-      ! integrals(:, 2) are G^+, but the formula is that dG^+/dz = G^-
-      ! Here is the correction
-      nablaG(3) = nablaG(3) + 2*dzdx3/r1
-    elseif (gf_singularities == HIGH_FREQ) then
-      ! we have nabla G^+, but we actually need nabla G^-
-      nablaG(1) = nablaG(1) - 2*drdx1*r/r1**3
-      nablaG(2) = nablaG(2) - 2*drdx2*r/r1**3
-      nablaG(3) = nablaG(3) - 2*dzdx3*z/r1**3
+      ! G is G^+, nablaG is nablaG^+
+      G = CMPLX(integrals(1), integrals(3), KIND=PRE)
+      dGdr = CMPLX(integrals(4), integrals(5), KIND=PRE)
+      nablaG(1) = drdx1 * dGdr
+      nablaG(2) = drdx2 * dGdr
+      nablaG(3) = dzdx3 * G + 2*dzdx3/r1
+    else if (gf_singularities == HIGH_FREQ) then
+      ! G is G^-, nablaG is nablaG^-
+      G = CMPLX(integrals(2), integrals(3), KIND=PRE)
+      dGdr = CMPLX(integrals(4), integrals(5), KIND=PRE)
+      nablaG(1) = drdx1 * dGdr - 2*drdx1*r/r1**3
+      nablaG(2) = drdx2 * dGdr - 2*drdx2*r/r1**3
+      nablaG(3) = dzdx3 * G    - 2*dzdx3*z/r1**3
     endif
 
     G = wavenumber * G
@@ -282,7 +268,7 @@ CONTAINS
     INTEGER,                                  INTENT(IN) :: tabulation_grid_shape
     REAL(KIND=PRE), DIMENSION(:),             INTENT(IN) :: tabulated_r_range
     REAL(KIND=PRE), DIMENSION(:),             INTENT(IN) :: tabulated_z_range
-    REAL(KIND=PRE), DIMENSION(size(tabulated_r_range), size(tabulated_z_range), 2, 2), INTENT(IN) :: tabulated_integrals
+    REAL(KIND=PRE), DIMENSION(:, :, :),       INTENT(IN) :: tabulated_integrals
 
     ! Prony decomposition for finite depth
     INTEGER,                                  INTENT(IN) :: NEXP

--- a/capytaine/green_functions/libDelhommeau/src/constants.f90
+++ b/capytaine/green_functions/libDelhommeau/src/constants.f90
@@ -17,6 +17,8 @@ MODULE CONSTANTS
   REAL(KIND=PRE), PARAMETER    :: LOG_2 = LOG(REAL(2d0, kind=pre))
   COMPLEX(KIND=PRE), PARAMETER :: II = (ZERO, ONE) ! Imaginary unit
 
+  integer, parameter :: nb_tabulated_values = 5
+
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   ! Parameters for different variants of the Green function.

--- a/capytaine/green_functions/libDelhommeau/src/matrices.f90
+++ b/capytaine/green_functions/libDelhommeau/src/matrices.f90
@@ -55,7 +55,7 @@ CONTAINS
     INTEGER,                                  INTENT(IN) :: tabulation_nb_integration_points
     REAL(KIND=PRE), DIMENSION(:),             INTENT(IN) :: tabulated_r_range
     REAL(KIND=PRE), DIMENSION(:),             INTENT(IN) :: tabulated_z_range
-    REAL(KIND=PRE), DIMENSION(:, :, :, :),    INTENT(IN) :: tabulated_integrals
+    REAL(KIND=PRE), DIMENSION(:, :, :),       INTENT(IN) :: tabulated_integrals
 
     ! Prony decomposition for finite depth Green function
     INTEGER,                                  INTENT(IN) :: NEXP

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,7 +35,10 @@ Internals
 
 * Rename ``tabulation_method`` parameter of :class:`~capytaine.green_functions.delhommeau.Delhommeau` as the more descriptive ``tabulation_grid_shape``, and similarly for internal variables. (:pull:`503`)
 
-* The compiled Fortran extension is not split into a ``Delhommeau`` and a ``XieDelhommeau`` version anymore. The computation of the latter can be achieved by the run-time parameter ``gf_singularities`` of the class :class:`~capytaine.green_functions.delhommeau.Delhommeau` class. The class :class:`~capytaine.green_functions.delhommeau.XieDelhommeau` is kept for backward compatibility (:pull:`475`). The tabulation is always the tabulation of the ``low_freq`` wave part (formerly ``XieDelhommeau``) to simplify the implementation (:pull:`508`). The finite depth Green function is always computed using the ``low_freq`` infinite water depth, so the ``gf_singularities`` parameter has no effect in finite depth. (:pull:`507`).
+* The compiled Fortran extension is not split into a ``Delhommeau`` and a ``XieDelhommeau`` version anymore.
+  The computation of the latter can be achieved by the run-time parameter ``gf_singularities`` of the class :class:`~capytaine.green_functions.delhommeau.Delhommeau` class. The class :class:`~capytaine.green_functions.delhommeau.XieDelhommeau` is kept for backward compatibility (:pull:`475`).
+  The finite depth Green function is always computed using the ``low_freq`` infinite water depth, so the ``gf_singularities`` parameter has no effect in finite depth. (:pull:`507`).
+  The tabulation stores the data of both variants and is thus slightly longer to initialize and slightly larger to store in memory (:pull:`543`).
 
 -------------------------------
 New in version 2.1 (2024-04-08)

--- a/docs/theory_manual/theory.rst
+++ b/docs/theory_manual/theory.rst
@@ -186,7 +186,7 @@ Introducing the dimensionless variables :math:`r = k \sqrt{(\xi_1 - x_1)^2 + (\x
 .. math::
     \mathcal{G}(r, z) & = \frac{1}{\sqrt{r^2 + z^2}} + \frac{2}{\pi} \Re \left( \int^{\pi/2}_{-\pi/2}  J(\zeta(r, z, \theta)) \, \mathrm{d} \theta \right) \\
     & \qquad \qquad \qquad \qquad + 2 i \Re \left( \int^{\pi/2}_{-\pi/2} e^{\zeta (r, z, \theta)} \, \mathrm{d} \theta \right)
-    :label: green_function_inf_depth_xie
+    :label: green_function_inf_depth_low_freq
 
 where
 
@@ -204,7 +204,7 @@ and
     \zeta (r, z, \theta) = z + i r \cos \theta.
     :label: def_zeta
 
-The first term of :eq:`green_function_inf_depth_xie` is actually a Rankine-type singularity similar to the first term of :eq:`green_function_inf_depth`, except that one of the point has been reflected through the free surface.
+The first term of :eq:`green_function_inf_depth_low_freq` is actually a Rankine-type singularity similar to the first term of :eq:`green_function_inf_depth`, except that one of the point has been reflected through the free surface.
 
 Variants of the formulation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -225,7 +225,7 @@ The above lemma allows to retrieve the expression of the Green function found e.
 .. math::
     \mathcal{G}(r, z) & = - \frac{1}{\sqrt{r^2 + z^2}} + \frac{2}{\pi} \Re \left( \int^{\pi/2}_{-\pi/2} \left( J(\zeta(r, z, \theta)) - \frac{1}{\zeta(r, z, \theta)} \right) \, \mathrm{d} \theta \right) \\
     & \qquad \qquad \qquad \qquad + 2 i \Re \left( \int^{\pi/2}_{-\pi/2} e^{\zeta (r, z, \theta)} \, \mathrm{d} \theta \right)
-    :label: green_function_inf_depth_del
+    :label: green_function_inf_depth_high_freq
 
 (Note the minus sign in front of the first term.)
 
@@ -360,6 +360,7 @@ that is, using :numref:`Lemma {number} <integrate_one_over_zeta>`
     In finite depth, some terms of the derivative with respect to :math:`x_3` are symmetric and some are antisymmetric.
 
 
+
 Higher order derivative
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -394,23 +395,25 @@ All higher order derivative can be expressed with the help of :math:`\mathcal{G}
 Delhommeau's method for computation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Delhommeau's method is based on expression :eq:`green_function_inf_depth_del` of the Green function.
-This expression of the Green function and its derivative require the evaluation of the following real-valued integrals:
+The current version of Capytaine can use either the low-frequency variant :eq:`green_function_inf_depth_low_freq` or high-frequency variant :eq:`green_function_inf_depth_high_freq` when evaluating the Green function and its integral over a panel.
+For this purpose, the following values needs to be computed:
 
 .. math::
-    D_1(r, z) & = \frac{1}{\pi} \Re \left( \int^{\pi/2}_{-\pi/2} i \cos(\theta) \left( J(\zeta) - \frac{1}{\zeta} \right) \, \mathrm{d} \theta \right) \\
-    D_2(r, z) & = \Re \left( \int^{\pi/2}_{-\pi/2} i \cos(\theta) e^{\zeta} \, \mathrm{d} \theta \right) \\
-    Z_1(r, z) & = \frac{1}{\pi} \Re \left( \int^{\pi/2}_{-\pi/2} \left( J(\zeta) - \frac{1}{\zeta} \right) \, \mathrm{d} \theta \right) \\
-    Z_2(r, z) & = \Re \left( \int^{\pi/2}_{-\pi/2} e^{\zeta} \, \mathrm{d} \theta \right)
+    I_1(r, z) & = \frac{2}{\pi} \Re \left( \int^{\pi/2}_{-\pi/2} J(\zeta) \, \mathrm{d} \theta \right) \\
+    I_2(r, z) & = \frac{2}{\pi} \Re \left( \int^{\pi/2}_{-\pi/2} \left( J(\zeta) - \frac{1}{\zeta} \right) \, \mathrm{d} \theta \right) \\
+    I_3(r, z) & = 2 \Re \left( \int^{\pi/2}_{-\pi/2} e^{\zeta} \, \mathrm{d} \theta \right) \\
+    I_4(r, z) & = \frac{2}{\pi} \Re \left( \int^{\pi/2}_{-\pi/2} i \cos(\theta) \left( J(\zeta) - \frac{1}{\zeta} \right) \, \mathrm{d} \theta \right) \\
+    I_5(r, z) & = 2 \Re \left( \int^{\pi/2}_{-\pi/2} i \cos(\theta) e^{\zeta} \, \mathrm{d} \theta \right)
 
-
-then
+then :eq:`green_function_inf_depth_low_freq` reads
 
 .. math::
-   \mathcal{G}(r, z) = \frac{-1}{\sqrt{r^2 + z^2}} + 2 Z_1(r, z) + 2 i Z_2(r, z).
+   \mathcal{G}(r, z) = \frac{1}{\sqrt{r^2 + z^2}} + I_1(r, z) + i I_3(r, z).
 
-.. note::
-   The definition of :math:`D_1`, :math:`D_2`, :math:`Z_1` and :math:`Z_2` may differ from the original one from Delhommeau by the :math:`1/\pi` factor.
+and :eq:`green_function_inf_depth_high_freq` reads
+
+.. math::
+   \mathcal{G}(r, z) = \frac{-1}{\sqrt{r^2 + z^2}} + I_2(r, z) + i I_3(r, z).
 
 To limit the computational cost of the evaluation of these integrals, they are precomputed for selected values of :math:`r` and :math:`z` and stored in a table.
 When evaluating the Green function, the values of the integrals are retrieved by interpolating the values in the tables.
@@ -418,49 +421,20 @@ When evaluating the Green function, the values of the integrals are retrieved by
 For large values of :math:`r` and :math:`z`, these integrals are asymptotically approximated by the following expressions:
 
 .. math::
-      D_1(r, z) & \simeq -e^z \sqrt{\frac{2\pi}{r}} \left(\cos(r - \pi/4) - \frac{1}{2r} \sin(r-\pi/4) \right) + \frac{r}{(r^2 + z^2)^{3/2}} \\
-      D_2(r, z) & \simeq -e^z \sqrt{\frac{2\pi}{r}} \left( \sin(r - \pi/4) + \frac{1}{2r} \cos(r - \pi/4) \right) \\
-      Z_1(r, z) & \simeq - e^z \sqrt{\frac{2\pi}{r}} \sin(r - \pi/4) + \frac{z}{(r^2 + z^2)^{3/2}} \\
-      Z_2(r, z) & \simeq e^z \sqrt{\frac{2\pi}{r}} \cos(r - \pi/4)
+      I_1(r, z) & \simeq - 2 e^z \sqrt{\frac{2\pi}{r}} \sin(r - \pi/4) + \frac{2 z}{(r^2 + z^2)^{3/2}} - \frac{2}{\sqrt{r^2 + z^2}} \\
+      I_2(r, z) & \simeq - 2 e^z \sqrt{\frac{2\pi}{r}} \sin(r - \pi/4) + \frac{2 z}{(r^2 + z^2)^{3/2}} \\
+      I_3(r, z) & \simeq 2 e^z \sqrt{\frac{2\pi}{r}} \cos(r - \pi/4) \\
+      I_4(r, z) & \simeq - 2 e^z \sqrt{\frac{2\pi}{r}} \left( \cos(r - \pi/4) - \frac{1}{2r} \sin(r-\pi/4) \right) + \frac{2 r}{(r^2 + z^2)^{3/2}} \\
+      I_5(r, z) & \simeq - 2 e^z \sqrt{\frac{2\pi}{r}} \left( \sin(r - \pi/4) + \frac{1}{2r} \cos(r - \pi/4) \right)
 
 
 Incorporating these asymptotic approximation in the expression of the Green function, one gets:
 
 .. math::
-    \mathcal{G}(r, z) \simeq & -\frac{1}{\sqrt{r^2 + z^2}} - 2 k e^z \sqrt{\frac{2\pi}{r}} \left(\sin(r - \pi/4) - i\cos(r - \pi/4)\right) \\
-   & \qquad\qquad\qquad\qquad + 2 k \frac{z}{(r^2 + z^2)^{3/2}}
+    \mathcal{G}(r, z) \simeq & -\frac{1}{\sqrt{r^2 + z^2}} - 2 e^z \sqrt{\frac{2\pi}{r}} \left(\sin(r - \pi/4) - i\cos(r - \pi/4)\right) \\
+   & \qquad\qquad\qquad\qquad + 2 \frac{z}{(r^2 + z^2)^{3/2}}
    :label: green_function_asymptotical_approx
 
-
-Xie's variant
-~~~~~~~~~~~~~
-
-A slight variant is presented in [X18]_. The authors noticed that the
-interpolation of the integral :math:`Z_1` can be inaccurate due to the
-singularity :math:`\frac{1}{\zeta}`.
-Hence, they proposed to use :eq:`green_function_inf_depth_xie` and to tabulate the integral
-
-.. math::
-    \widetilde{Z_1}(r, z) = \frac{1}{\pi} \Re \left( \int^{\pi/2}_{-\pi/2} J(\zeta) \, \mathrm{d} \theta \right)
-
-By using :numref:`Lemma {number} <integrate_one_over_zeta>`, one has
-
-.. math::
-   Z_1 = \widetilde{Z_1} + \frac{1}{\sqrt{r^2 + z^2}}
-
-then
-
-.. math::
-   \mathcal{G}(r, z) = \frac{1}{\sqrt{r^2 + z^2}} + 2 \widetilde{Z_1}(r, z) + 2 i Z_2(r, z).
-
-The asymptotical expression for :math:`\widetilde{Z_1}` reads
-
-.. math::
-   \widetilde{Z_1}(r, z) \simeq - e^z \sqrt{\frac{2\pi}{r}} \sin(r - \pi/4) + \frac{z}{(r^2 + z^2)^{3/2}} - \frac{1}{\sqrt{r^2 + z^2}} \\
-
-while the asymptotic Green function still reads :eq:`green_function_asymptotical_approx`.
-
-Both the original Delhommeau's method and Xie's variant are implemented in Capytaine.
 
 In finite depth
 ---------------

--- a/docs/theory_manual/theory.rst
+++ b/docs/theory_manual/theory.rst
@@ -390,6 +390,7 @@ All higher order derivative can be expressed with the help of :math:`\mathcal{G}
 .. note::
    The same derivation is done in e.g. [N20]_ using instead the function :math:`F = \mathcal{G} - \frac{1}{\sqrt{r^2 + z^2}}` for which the expressions are slightly simpler.
 
+
 Delhommeau's method for computation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pytest/test_bem_fortran_core.py
+++ b/pytest/test_bem_fortran_core.py
@@ -1,10 +1,24 @@
 import pytest
 import numpy as np
-from scipy.special import j0
 import capytaine as cpt
 
+# def test_exponential_integral(x, y):
+#     # Compare with Scipy implementation
+#     from scipy.special import exp1
+#     z = x + 1j*y
+#
+#     gf = cpt.Delhommeau()
+#     def E1(z):
+#         return np.exp(-z)*gf.fortran_core.delhommeau_integrals.exp_e1(z)
+#
+#     assert np.isclose(E1(z), exp1(z), rtol=1e-3)
+
+#     # Test property (A3.5) of the function according to [Del, p.367].
+#     if y != 0.0:
+#         assert np.isclose(E1(np.conjugate(z)), np.conjugate(E1(z)), rtol=1e-3)
 
 def test_infinite_depth_gf():
+    from scipy.special import j0
     gf = cpt.Delhommeau()
     def wave_part(*args):
         return gf.fortran_core.green_wave.wave_part_infinite_depth(

--- a/pytest/test_bem_fortran_core.py
+++ b/pytest/test_bem_fortran_core.py
@@ -1,0 +1,51 @@
+import pytest
+import numpy as np
+from scipy.special import j0
+import capytaine as cpt
+
+
+def test_infinite_depth_gf():
+    gf = cpt.Delhommeau()
+    def wave_part(*args):
+        return gf.fortran_core.green_wave.wave_part_infinite_depth(
+                *args[:3], gf.tabulation_nb_integration_points, gf.tabulation_grid_shape_index,
+                gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals,
+                args[3])
+    xi = np.array([0.0, 0.0, -0.5])
+    xj = np.array([0.0, 1.0, -0.5])
+    k = 2.0
+    g_lf, nablag_lf = wave_part(xi, xj, k, 0)
+    g_hf, nablag_hf = wave_part(xi, xj, k, 1)
+    r = k * np.linalg.norm(xi[:2] - xj[:2])
+    z = k * (xi[2] + xj[2])
+    assert g_hf.real + 2*k/np.hypot(r, z) == pytest.approx(g_lf.real, rel=1e-4)
+    assert g_lf.imag == pytest.approx(g_hf.imag)
+    assert g_lf.imag == pytest.approx(2*np.pi*k*np.exp(z)*j0(r), rel=1e-4)
+
+
+@pytest.mark.parametrize("gf_singularities", ["low_freq", "high_freq"])
+def test_infinite_depth_gf_finite_differences(gf_singularities):
+    gf = cpt.Delhommeau(gf_singularities=gf_singularities)
+    def wave_part(*args):
+        return gf.fortran_core.green_wave.wave_part_infinite_depth(
+                *args[:3], gf.tabulation_nb_integration_points, gf.tabulation_grid_shape_index,
+                gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals,
+                gf.gf_singularities_index)[0]
+    def nabla_wave_part(*args):
+        return gf.fortran_core.green_wave.wave_part_infinite_depth(
+                *args[:3], gf.tabulation_nb_integration_points, gf.tabulation_grid_shape_index,
+                gf.tabulated_r_range, gf.tabulated_z_range, gf.tabulated_integrals,
+                gf.gf_singularities_index)[1]
+    k = 1.0
+    xi = np.array([0.0, 0.0, -0.5])
+    xj = np.array([1.0, 1.0, -0.5])
+    x_eps = np.array([1e-3, 0.0, 0.0])
+    y_eps = np.array([0.0, 1e-3, 0.0])
+    z_eps = np.array([0.0, 0.0, 1e-3])
+    g = wave_part(xi, xj, k)
+    g_x = (wave_part(xi + x_eps, xj, k) - g)/np.linalg.norm(x_eps)
+    g_y = (wave_part(xi + y_eps, xj, k) - g)/np.linalg.norm(y_eps)
+    g_z = (wave_part(xi + z_eps, xj, k) - g)/np.linalg.norm(z_eps)
+    nabla_g = np.array([g_x, g_y, g_z])
+    nablag_ref = nabla_wave_part(xi, xj, k)
+    assert nablag_ref == pytest.approx(nabla_g, abs=1e-2)

--- a/pytest/test_bem_green_functions.py
+++ b/pytest/test_bem_green_functions.py
@@ -7,59 +7,6 @@ import numpy as np
 import capytaine as cpt
 
 
-
-# from numpy import pi
-# from scipy.integrate import quad
-# from scipy.misc import derivative
-# from scipy.optimize import newton
-# from scipy.special import exp1
-# from hypothesis import given
-
-# def E1(z):
-#     return np.exp(-z)*Delhommeau_f90.initialize_green_wave.exp_e1(z)
-#
-# @given(floats(min_value=-1e2, max_value=-1e-2), floats(min_value=-1e2, max_value=1e2))
-# def test_exponential_integral(x, y):
-#     z = x + 1j*y
-#
-#     # Compare with Scipy implementation
-#     assert np.isclose(E1(z), exp1(z), rtol=1e-3)
-#
-#     # Test property (A3.5) of the function according to [Del, p.367].
-#     if y != 0.0:
-#         assert np.isclose(E1(np.conjugate(z)), np.conjugate(E1(z)), rtol=1e-3)
-#
-#     # BROKEN...
-#     # def derivative_of_complex_function(f, z, **kwargs):
-#     #     direction = 1
-#     #     return derivative(lambda eps: f(z + eps*direction), 0.0, **kwargs)
-#     # if abs(x) > 1 and abs(y) > 1:
-#     #     assert np.isclose(
-#     #         derivative_of_complex_function(Delhommeau_f90.initialize_green_wave.gg, z),
-#     #         Delhommeau_f90.initialize_green_wave.gg(z) - 1.0/z,
-#     #         atol=1e-2)
-#
-
-# CHECK OF THE THEORY, NOT THE CODE ITSELF
-# Not necessary to run every time...
-#
-# @given(r=floats(min_value=0, max_value=1e2),
-#        z=floats(min_value=-16, max_value=-1),
-#        k=floats(min_value=0.1, max_value=10)
-#        )
-# def test_zeta(r, z, k):
-#     """Check expression k/π ∫ 1/ζ(θ) dθ = - 1/r """
-
-#     def one_over_zeta(theta):
-#         return np.real(1/(k*(z + 1j*r*np.cos(theta))))
-
-#     int_one_over_zeta, *_ = quad(one_over_zeta, -pi/2, pi/2)
-
-#     assert np.isclose(k/pi * int_one_over_zeta,
-#                       -1/(np.sqrt(r**2 + z**2)),
-#                       rtol=1e-4)
-
-
 gfs = [
         cpt.Delhommeau(tabulation_nr=328, tabulation_nz=46, tabulation_nb_integration_points=251, tabulation_grid_shape="legacy"),
         cpt.XieDelhommeau(tabulation_nr=328, tabulation_nz=46, tabulation_nb_integration_points=251, tabulation_grid_shape="legacy"),


### PR DESCRIPTION
This kind of reverts #508, as the tabulation data is not always the low_freq variant.

This might slightly deteriorate the performance as the tabulation interpolation is done for one more field, but it could be fixed in the future, once #298 and #534 have been figured out.