### PR TITLE
fix: breaking change in linear solver in Numpy 2.0

### DIFF
--- a/capytaine/matrices/linear_solvers.py
+++ b/capytaine/matrices/linear_solvers.py
@@ -3,14 +3,13 @@
 They are based on numpy solvers with a thin layer for the handling of Hierarchical Toeplitz matrices.
 """
 # Copyright (C) 2017-2019 Matthieu Ancellin
-# See LICENSE file at <https://github.com/mancellin/capytaine>
+# See LICENSE file at <https://github.com/capytaine/capytaine>
 
 import logging
 
 import numpy as np
 from scipy import linalg as sl
 from scipy.sparse import linalg as ssl
-from itertools import accumulate, chain
 
 from capytaine.matrices.block import BlockMatrix
 from capytaine.matrices.block_toeplitz import BlockSymmetricToeplitzMatrix, BlockCirculantMatrix
@@ -27,7 +26,7 @@ def solve_directly(A, b):
         blocks_of_diagonalization = A.block_diagonalize()
         fft_of_rhs = np.fft.fft(np.reshape(b, (A.nb_blocks[0], A.block_shape[0])), axis=0)
         try:  # Try to run it as vectorized numpy arrays.
-            fft_of_result = np.linalg.solve(blocks_of_diagonalization, fft_of_rhs)
+            fft_of_result = np.linalg.solve(blocks_of_diagonalization, fft_of_rhs[..., np.newaxis])[..., 0]
         except np.linalg.LinAlgError:  # Or do the same thing with list comprehension.
             fft_of_result = np.array([solve_directly(block, vec) for block, vec in zip(blocks_of_diagonalization, fft_of_rhs)])
         result = np.fft.ifft(fft_of_result, axis=0).reshape((A.shape[1],))

--- a/capytaine/post_pro/rao.py
+++ b/capytaine/post_pro/rao.py
@@ -55,6 +55,6 @@ def rao(dataset, wave_direction=None, dissipation=None, stiffness=None):
     # Solve and add coordinates
     rao_dims = [d for d in H.dims if d != 'influenced_dof']
     rao_coords = {c: H.coords[c] for c in H.coords if c != 'influenced_dof'}
-    rao = xr.DataArray(np.linalg.solve(H, fex), coords=rao_coords, dims=rao_dims)
+    rao = xr.DataArray(np.linalg.solve(H.values, fex.values[..., np.newaxis])[..., 0], coords=rao_coords, dims=rao_dims)
 
     return rao

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -41,6 +41,8 @@ Bug fixes
 
 * Providing the frequency as a scalar coordinate in the test matrix does not result in the value being ignored anymore (:issue:`547` and :pull:`548`).
 
+* Fix issue due to breaking change in linear solver broadcasting in Numpy 2.0 (:issue:`550`).
+
 Internals
 ~~~~~~~~~
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -95,5 +95,5 @@ def build_and_test_on_nightly_builds(session):
                     "numpy", "scipy", "pandas", "xarray", "rich")
     session.install("meson-python", "ninja", "charset-normalizer")
     session.install("--no-deps", "--no-build-isolation", ".")
-    session.install("pytest")
+    session.install("pytest", "matplotlib")
     run_tests(session)


### PR DESCRIPTION
Fix #550