### PR TITLE
build: use OpenMP in MacOS wheels

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -51,15 +51,10 @@ install_subdir(
   )
 # Alternatively: would need to list all the .py files and use py3.install_source()
 
-if build_machine.system() == 'darwin'
-  omp = []  # Waiting for https://github.com/mesonbuild/meson/issues/7435
-else
-  omp = dependency('openmp')
-endif
 
 args = ['-cpp']
 link_args = ['-lquadmath']  # Required for the Windows build with cibuildwheel
-deps = [py3_dep, omp]
+deps = [py3_dep, dependency('openmp')]
 
 py3.extension_module('Delhommeau_float32',
            float32, libDelhommeau_src, Delhommeau_float32_f2py_wrapper, incdir_f2py+'/fortranobject.c',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ docs = ["sphinx", "sphinx-toolbox", "sphinxcontrib-proof", "sphinxcontrib-mermai
 [build-system]
 build-backend = 'mesonpy'
 requires = [
+    "meson>=1.5",
     "meson-python",
     "charset-normalizer",
     "numpy>=2.0.0; python_version>='3.9'",


### PR DESCRIPTION
This is supposed to be supported by Meson now.