### PR TITLE
fix: cache irregular frequency check

### DIFF
--- a/capytaine/bodies/bodies.py
+++ b/capytaine/bodies/bodies.py
@@ -5,7 +5,7 @@
 import logging
 import copy
 from itertools import chain, accumulate, zip_longest
-from functools import cached_property
+from functools import cached_property, cache
 
 import numpy as np
 import xarray as xr
@@ -1107,6 +1107,7 @@ respective inertia coefficients are assigned as NaN.")
         else:
             return 8*self.mesh.faces_radiuses.max()
 
+    @cache
     def first_irregular_frequency_estimate(self, *, g=9.81):
         r"""Estimates the angular frequency of the lowest irregular
         frequency.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,11 @@ Bug fixes
 
 * Fixes usage of ``ReflectionSymmetricMesh`` with direct solver (:issue:`593` and :pull:`594`).
 
+* Do not recompute the same
+  :meth:`~capytaine.bodies.bodies.FloatingBody.first_irregular_frequency_estimate``
+  for the same body several times.
+  Also better expose the ``_check_wavelength`` option to skip wavelength check,
+  including irregular frequency estimation. (:issue:`601` and :pull:`602`).
 
 -------------------------------
 New in version 2.2 (2024-07-08)


### PR DESCRIPTION
Kinda fix #601 by
- better exposing and documenting `_check_wavelength` to skip check if necessary
- do not redo the same `first_irregular_frequency_estimate` for each problem with the same body.
