### PR TITLE
fix: raise error when inconsitent mesh and dofs

### DIFF
--- a/capytaine/bem/problems_and_results.py
+++ b/capytaine/bem/problems_and_results.py
@@ -193,6 +193,8 @@ class LinearPotentialFlowProblem:
                     or len(self.body.mesh.faces) == 0):
                 raise ValueError(f"The mesh of the body {self.body.__short_str__()} is empty.")
 
+            self.body._check_dofs_shape_consistency()
+
             panels_above_fs = self.body.mesh.faces_centers[:, 2] >= self.free_surface + 1e-8
             panels_below_sb = self.body.mesh.faces_centers[:, 2] <= -self.water_depth
             if (any(panels_above_fs) or any(panels_below_sb)):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,6 +46,8 @@ Bug fixes
 
 * After joining several bodies, editing the mesh of one of the components does not affect the joined body anymore (:issue:`660` and :pull:`662`:).
 
+* Check the consistency of the dofs with the mesh and raises ``ValueError`` when an inconsistency is detected (:pull:`663`).
+
 Internals
 ~~~~~~~~~
 

--- a/pytest/test_bem_problems_and_results.py
+++ b/pytest/test_bem_problems_and_results.py
@@ -78,6 +78,15 @@ def test_LinearPotentialFlowProblem(sphere):
     assert res.body is pb.body
 
 
+def test_mesh_inconsistent_with_dofs(sphere):
+    n = sphere.mesh.nb_faces
+    sphere.dofs["Wrong_dof"] = np.ones((n//2, 3))
+    with pytest.raises(ValueError):
+        cpt.RadiationProblem(body=sphere, wavenumber=1.0)
+    with pytest.raises(ValueError):
+        cpt.DiffractionProblem(body=sphere, wavenumber=1.0)
+
+
 def test_mesh_above_the_free_surface(caplog):
     with caplog.at_level(logging.WARNING):
         body = cpt.FloatingBody(mesh=cpt.mesh_sphere(), dofs=cpt.rigid_body_dofs())

--- a/pytest/test_bodies.py
+++ b/pytest/test_bodies.py
@@ -165,6 +165,13 @@ def test_complicated_clipping_of_dofs():
     assert len(clipped_body.dofs["Heave"]) == clipped_body.mesh.nb_faces
 
 
+def test_clipping_of_inconsistent_dof():
+    body = cpt.FloatingBody(cpt.mesh_sphere(), dofs=cpt.rigid_body_dofs())
+    body.mesh.keep_immersed_part()  # Dofs and mesh are now inconsistent
+    with pytest.raises(ValueError):
+        body.keep_immersed_part()
+
+
 @pytest.mark.xfail
 def test_clipping_of_dofs_with_degenerate_faces():
     vertices = np.array([


### PR DESCRIPTION
Would also have avoided #660 