### PR TITLE
fix: also NaN in radiation damping when failed

### DIFF
--- a/capytaine/bem/problems_and_results.py
+++ b/capytaine/bem/problems_and_results.py
@@ -510,7 +510,7 @@ class LinearPotentialFlowResult:
 class FailedLinearPotentialFlowResult(LinearPotentialFlowResult):
     def __init__(self, problem, exception):
         LinearPotentialFlowResult.__init__(self, problem)
-        self.forces = {dof: np.nan for dof in self.influenced_dofs}
+        self.forces = {dof: np.nan + 1j*np.nan for dof in self.influenced_dofs}
         self.exception = exception
 
 
@@ -579,5 +579,5 @@ class RadiationResult(LinearPotentialFlowResult):
 class FailedRadiationResult(RadiationResult):
     def __init__(self, problem, exception):
         RadiationResult.__init__(self, problem)
-        self.forces = {dof: np.nan for dof in self.influenced_dofs}
+        self.forces = {dof: np.nan + 1j*np.nan for dof in self.influenced_dofs}
         self.exception = exception

--- a/pytest/test_bem_problems_and_results.py
+++ b/pytest/test_bem_problems_and_results.py
@@ -259,3 +259,10 @@ def test_failed_resolution_catched(broken_bem_solver, sphere):
     pb = cpt.DiffractionProblem(body=sphere, wavenumber=1.0, wave_direction=0.0)
     failed_res = broken_bem_solver.solve_all([pb])[0]
     assert isinstance(failed_res, FailedDiffractionResult)
+
+
+def test_failed_resolution_replaced_by_nan(broken_bem_solver, sphere):
+    pb = cpt.RadiationProblem(body=sphere, wavenumber=1.0, radiating_dof="Heave")
+    failed_ds = cpt.assemble_dataset(broken_bem_solver.solve_all([pb]))
+    assert np.isnan(failed_ds.added_mass.values[0, 0, 0])
+    assert np.isnan(failed_ds.radiation_damping.values[0, 0, 0])


### PR DESCRIPTION
Failed results used to give a zero for radiation damping. It should be NaN like the added mass.