### PR TITLE
Keep input frequency order in assemble_matrices (fixes #797)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -239,6 +239,8 @@ Bug fixes
 
 * The RAO used to be computed wrongly with the transpose of the actual transfer function. (:issue:`891` and :pull:`892`)
 
+* :func:`~capytaine.io.xarray.assemble_matrices` now returns the matrices ordered along the frequency axis like the input ``results``, instead of sorted by increasing frequency. (:issue:`797`)
+
 Internals
 ~~~~~~~~~
 

--- a/pytest/test_io_xarray.py
+++ b/pytest/test_io_xarray.py
@@ -153,6 +153,23 @@ def test_assemble_matrices_no_data():
     with pytest.raises(ValueError):
         cpt.assemble_matrices([])
 
+
+def test_assemble_matrices_frequency_order(sphere, solver):
+    # The matrices should be ordered like the input results, and not sorted by
+    # increasing frequency as in `assemble_dataset`.
+    # See https://github.com/capytaine/capytaine/issues/797
+    omegas = [1.5, 0.5, 1.0]  # deliberately not sorted
+    # Solve one by one to keep the results in the requested (unsorted) order.
+    res = [solver.solve(cpt.RadiationProblem(body=sphere, radiating_dof="Heave", omega=omega))
+           for omega in omegas]
+
+    A, B, _ = cpt.assemble_matrices(res)
+
+    expected_A = np.array([r.added_mass["Heave"] for r in res])
+    expected_B = np.array([r.radiation_damping["Heave"] for r in res])
+    np.testing.assert_allclose(A.squeeze(), expected_A)
+    np.testing.assert_allclose(B.squeeze(), expected_B)
+
 #######################################################################
 #                          Assemble dataset                           #
 #######################################################################

--- a/src/capytaine/io/xarray.py
+++ b/src/capytaine/io/xarray.py
@@ -544,9 +544,26 @@ def assemble_matrices(results):
     3-ple of (np.arrays or None)
         The added mass matrix, the radiation damping matrix and the excitation force.
         If the data are no available in the results, returns None instead.
+
+        The matrices are ordered along their frequency axis in the same order as
+        the frequencies appear in ``results``, rather than sorted by increasing
+        frequency as in the dataset returned by :func:`assemble_dataset`.
     """
 
     ds = assemble_dataset(results)
+
+    # `assemble_dataset` sorts the frequencies by increasing value. For the bare
+    # matrices, reorder the frequency axis to match the order in which the
+    # frequencies appear in `results`, which is less surprising when the matrices
+    # are read without the labelled coordinates of the dataset.
+    # See https://github.com/capytaine/capytaine/issues/797
+    freq_type = next(
+        (ft for ft in ('omega', 'freq', 'period', 'wavelength', 'wavenumber') if ft in ds.dims),
+        None,
+    )
+    if freq_type is not None:
+        ordered_freqs = list(dict.fromkeys(getattr(result, freq_type) for result in results))
+        ds = ds.sel({freq_type: ordered_freqs})
 
     if "added_mass" in ds:
         A = np.atleast_2d(ds.added_mass.values.squeeze())


### PR DESCRIPTION
### Description

Fixes #797.

`assemble_matrices` delegates to `assemble_dataset`, which sorts the frequencies by increasing value. The returned *bare* matrices were therefore ordered by increasing frequency rather than following the order of the input `results`. Because these matrices carry no labelled coordinates (that's the point of the function — a teaching-friendly alternative to the xarray dataset), this silent reordering is easy to miss.

```python
import numpy as np
import capytaine as cpt

body = cpt.FloatingBody(mesh=cpt.mesh_sphere(), dofs=cpt.rigid_body_dofs(rotation_center=(0, 0, 0)))
omega_range = 2 * np.pi / np.array([5.0, 10.0, 15.0])  # decreasing omega
pbs = [cpt.RadiationProblem(omega=omega, radiating_dof='Heave', body=body.immersed_part())
       for omega in omega_range]
res = cpt.BEMSolver().solve_all(pbs)

A, B, F = cpt.assemble_matrices(res)
# before: A[:, 2] is sorted by increasing omega, not in the order of `res`
# after:  A[:, 2] follows the order of `res`
```

### Change

`assemble_matrices` now reorders the frequency axis of the returned matrices to match the order in which the frequencies appear in the input `results`. The `assemble_dataset` behavior (and its sorted xarray coordinates) is unchanged — only the bare-matrix wrapper is affected.

### Tests

Added `test_assemble_matrices_frequency_order` in `pytest/test_io_xarray.py`: it solves radiation problems at frequencies given in a deliberately unsorted order and checks that the assembled `A`/`B` rows match the per-result values in input order. The test fails on `master` (matrices come back frequency-sorted) and passes with this change.

I also added a changelog entry under "Bug fixes".
