### PR TITLE
Fix test_nb_timer in case less than 3 cores are available

### DIFF
--- a/pytest/test_bem_solver.py
+++ b/pytest/test_bem_solver.py
@@ -120,8 +120,9 @@ def test_control_threads(sphere, n_jobs, n_threads):
 
 def test_nb_timer(sphere):
     pytest.importorskip("joblib")
+    from joblib import cpu_count
     solver = cpt.BEMSolver()
-    n_jobs = 3
+    n_jobs = min(cpu_count(), 3)
     problems = [
             cpt.RadiationProblem(body=sphere, radiating_dof="Surge", omega=omega)
             for omega in np.linspace(0.1, 3.0, 5)


### PR DESCRIPTION
Hello

When creating a GitHub codespace, I had only two cores available, meaning the test requiring 3 cores could only fail. This is why I have patched the number of cores for test `test_nb_timer `

BTW, if interested, I can push my Dockerfile that I use to run test.

```docker
FROM debian:13
RUN apt-get update && apt-get install -y \
    python3 \
    python3-pip \
    python3-venv \
    python-is-python3 \
    python3-dev \
    git \
    gfortran \
    just
RUN python3 -m pip install --break-system-packages uv
RUN python3 -m pip install --break-system-packages pygmsh==7.1.17
RUN python3 -m pip install --break-system-packages trimesh==5.0.0
WORKDIR /home/user/
ADD ./ ./capytaine/
#RUN uv install ./capytaine
#RUN uv run --with build python -m build --sdist
#RUN just test_in_py313_reference_env
```